### PR TITLE
ENH(?): if no explicit "latest" tag, return the latest (by build_date) for "latest"

### DIFF
--- a/_service_/requirements.txt
+++ b/_service_/requirements.txt
@@ -1,4 +1,4 @@
 click
 requests
 sanic>=20.12,<20.13
-sanic-cors
+sanic-cors~=0.10

--- a/_service_/serve.py
+++ b/_service_/serve.py
@@ -231,9 +231,10 @@ def main(json_path):
                 res[id_] = rec
         if 'latest' not in res:
             n_latest += 1
-            print(f"{n_latest:02d}/{len(raw['images'])} {name}: "
-                  f"adding detected 'latest' among {len(files)} records: "
-                  f"tag {latest['tag']} from {latest['build_date']}")
+            if not production:
+                print(f"{n_latest:02d}/{len(raw['images'])} {name}: "
+                      f"adding detected 'latest' among {len(files)} records: "
+                      f"tag {latest['tag']} from {latest['build_date']}")
             res['latest'] = latest
 
     # strip away all build_date's


### PR DESCRIPTION
While at it also made it usable in non-production mode, and fixed up
versionining needed for sanic-cors for that

With that - we would assign such implicit "latest" to 

<details>
<summary>955 out of 2910 collections</summary> 

```shell
01/2910 YeoLab/eclip-dev: adding detected 'latest' among 1 records: master from 2020-03-07T05:40:26.440Z
02/2910 vsoch/singularity-hello-world: adding detected 'latest' among 1 records: master from 2021-04-04T00:03:12.943Z
03/2910 alaindomissy/scbatch: adding detected 'latest' among 1 records: master from 2017-10-17T20:41:50.004Z
04/2910 vsoch/pe-predictive: adding detected 'latest' among 1 records: master from 2017-10-18T04:03:49.123Z
05/2910 satra/om-tensorflow: adding detected 'latest' among 1 records: master from 2017-10-19T18:03:08.226Z
06/2910 vsoch/singularity-nbconvert: adding detected 'latest' among 1 records: latex from 2017-10-20T13:19:09.986Z
07/2910 cokelaer/pacbio4all: adding detected 'latest' among 4 records: v3 from 2017-11-16T10:30:37.444Z
08/2910 qbicsoftware/qbic-singularity-pyenvcentraxx: adding detected 'latest' among 1 records: v1.0 from 2019-07-27T21:23:39.138Z
09/2910 qbicsoftware/qbic-singularity-megSAP: adding detected 'latest' among 1 records: v2017-10-25 from 2017-11-19T10:50:40.525Z
10/2910 jekriske/lolcow: adding detected 'latest' among 1 records: lowfat from 2020-08-02T16:26:43.616Z
11/2910 alfpark/batch-shipyard-singularity: adding detected 'latest' among 1 records: cli from 2019-08-02T22:01:05.431Z
12/2910 crbaird/ohpc: adding detected 'latest' among 1 records: 1.3.3.el7 from 2017-11-16T10:30:37.232Z
13/2910 openhpc/ohpc: adding detected 'latest' among 1 records: 1.3.3.el7 from 2017-11-16T10:30:36.862Z
14/2910 feelpp/singularity: adding detected 'latest' among 1 records: feelpp-toolboxes-latest from 2019-09-17T07:15:39.750Z
15/2910 glass-consortium/glasstools: adding detected 'latest' among 1 records: beta from 2019-11-10T23:21:28.210Z
16/2910 TomaszGolan/mlmpr: adding detected 'latest' among 5 records: caffe-dann-nocudnn from 2017-11-28T19:11:34.666Z
17/2910 qbicsoftware/qbic-singularity-salmon: adding detected 'latest' among 1 records: v0.8.2 from 2017-11-21T09:20:46.828Z
18/2910 NIH-HPC/singularity-examples: adding detected 'latest' among 7 records: rstudio from 2021-02-18T01:37:53.782Z
19/2910 qbicsoftware/qbic-singularity-diamond: adding detected 'latest' among 1 records: template from 2017-11-21T18:32:11.766Z
20/2910 cokelaer/graphviz4all: adding detected 'latest' among 1 records: v1 from 2019-08-12T10:01:23.355Z
21/2910 ruycastilho/GPUtest: adding detected 'latest' among 3 records: 1604 from 2020-06-11T10:06:41.853Z
22/2910 UNM-CARC/singularity-test: adding detected 'latest' among 3 records: centos from 2018-09-12T22:22:09.847Z
23/2910 UNM-CARC/FEniCS: adding detected 'latest' among 2 records: ubuntu from 2017-11-29T00:37:33.977Z
24/2910 gipert/baseos-containers: adding detected 'latest' among 2 records: g4.10.3 from 2020-06-16T18:06:55.563Z
25/2910 ResearchIT/nwchem: adding detected 'latest' among 1 records: 6.6-openmpi from 2017-12-07T15:25:40.550Z
26/2910 NBISweden/K9-WGS-Pipeline: adding detected 'latest' among 7 records: bwa-0.7.12 from 2020-11-19T06:09:28.279Z
27/2910 NuWro/builds: adding detected 'latest' among 4 records: 18.02.1 from 2021-03-04T11:49:54.459Z
28/2910 SebastianM-C/singularity: adding detected 'latest' among 2 records: 0.7 from 2018-09-07T02:36:49.039Z
29/2910 TakahisaShiratori/openfoam: adding detected 'latest' among 1 records: 4 from 2021-04-16T09:05:06.445Z
30/2910 whit2333/shub: adding detected 'latest' among 1 records: dd4hep from 2018-01-01T00:44:31.242Z
31/2910 bailsofhay/gears-singularity: adding detected 'latest' among 1 records: general from 2018-01-10T06:32:44.540Z
32/2910 vfonov/minc-toolkit-containers: adding detected 'latest' among 6 records: 1.9.16 from 2020-12-17T17:00:49.994Z
33/2910 billspat/mlmpr: adding detected 'latest' among 1 records: caffe-dann-nocudnn from 2018-01-12T01:02:31.135Z
34/2910 bilke/singularity-recipes: adding detected 'latest' among 5 records: centos7.ogs_6.1.0 from 2018-01-19T14:04:59.451Z
35/2910 khanlab/neuroglia-core: adding detected 'latest' among 7 records: v1.0.0 from 2019-08-15T19:28:32.266Z
36/2910 khanlab/neuroglia-dwi: adding detected 'latest' among 4 records: v1.4.1 from 2019-12-09T03:48:18.329Z
37/2910 akhanf/vasst-dev: adding detected 'latest' among 11 records: v0.0.4g from 2019-11-05T22:36:15.531Z
38/2910 gipert/my-containers: adding detected 'latest' among 8 records: texlive from 2020-04-25T07:17:11.458Z
39/2910 shahzebsiddiqui/eb-singularity: adding detected 'latest' among 9 records: git-lfs-1.1.1 from 2021-03-02T20:03:29.231Z
40/2910 khanlab/qsm_sstv: adding detected 'latest' among 2 records: v0.1.0 from 2018-06-11T18:30:26.230Z
41/2910 endrebak/singularity_recipes: adding detected 'latest' among 6 records: mendelianrandomization_0_3_0 from 2018-03-14T15:22:05.472Z
42/2910 belledon/container-workshop: adding detected 'latest' among 1 records: git-session from 2018-01-24T23:46:17.169Z
43/2910 octomike/singularity-containers: adding detected 'latest' among 2 records: openmx-jessie from 2018-01-26T02:08:37.344Z
44/2910 TheEtkinLab/ndmg: adding detected 'latest' among 1 records: v0.1.0 from 2018-05-13T10:34:42.468Z
45/2910 maxemil/singularity-container: adding detected 'latest' among 1 records: iqtree from 2018-01-30T14:49:35.398Z
46/2910 BIDS-Apps/ndmg: adding detected 'latest' among 1 records: v0.1.0 from 2020-07-29T06:45:52.709Z
47/2910 StanfordCosyne/pancakes: adding detected 'latest' among 6 records: spm12-base from 2018-02-13T08:25:31.541Z
48/2910 khanlab/mp2rage_correction: adding detected 'latest' among 2 records: v0.0.3 from 2019-12-08T19:49:41.144Z
49/2910 khanlab/retrieve_cfmm: adding detected 'latest' among 1 records: v0.0.5 from 2018-02-05T10:17:18.712Z
50/2910 hansendx/singularity_fsl_minimal: adding detected 'latest' among 1 records: 0.1 from 2020-01-08T19:37:27.184Z
51/2910 ozanarkancan/ReGROUND: adding detected 'latest' among 2 records: dgen from 2018-02-13T08:25:31.587Z
52/2910 Maaarcocr/comp3096_2018: adding detected 'latest' among 1 records: w2v from 2018-02-16T17:20:20.399Z
53/2910 raj76/singularity: adding detected 'latest' among 4 records: biocontainers from 2019-09-04T14:37:57.566Z
54/2910 AaronTHolt/openmpi_singularity: adding detected 'latest' among 1 records: spack_base from 2019-09-04T22:45:12.462Z
55/2910 bipinbachhao/atom: adding detected 'latest' among 3 records: 1.24.1 from 2018-10-19T18:21:05.368Z
56/2910 Wustl-Zhanglab/ATAC-seq_QC_analysis: adding detected 'latest' among 1 records: mm10 from 2018-03-03T01:06:30.189Z
57/2910 yarikoptic/vowpal_wabbit: adding detected 'latest' among 1 records: debian-unstable-amd64 from 2018-07-29T13:43:58.672Z
58/2910 ozanarkancan/Kindergarten: adding detected 'latest' among 1 records: kinetic from 2018-05-02T17:08:29.934Z
59/2910 bpuchala/casm-singularity: adding detected 'latest' among 1 records: 0.3.x from 2018-02-28T22:04:06.181Z
60/2910 faustus123/JLEIC_singularity: adding detected 'latest' among 1 records: 1.0.3 from 2018-04-05T22:27:29.963Z
61/2910 MPIB/singularity-ants: adding detected 'latest' among 1 records: 2.2.0 from 2021-01-01T13:54:47.017Z
62/2910 mbhall88/Singularity_recipes: adding detected 'latest' among 29 records: pandora from 2020-12-05T20:16:59.649Z
63/2910 MPIB/singularity-ashs: adding detected 'latest' among 1 records: fastashs.v1.0.0 from 2020-07-14T10:07:07.030Z
64/2910 MPIB/singularity-dtiprep: adding detected 'latest' among 1 records: 1.2.9 from 2019-09-13T17:03:45.911Z
65/2910 researchapps/sherlock: adding detected 'latest' among 2 records: pvacseq from 2021-03-15T23:49:44.707Z
66/2910 MPIB/singularity-mrtrix3: adding detected 'latest' among 2 records: 3.0_rc3 from 2021-01-01T14:07:23.788Z
67/2910 JohnLangford/vowpal_wabbit: adding detected 'latest' among 2 records: debian-unstable-i386 from 2018-07-05T12:20:14.255Z
68/2910 NYU-Molecular-Pathology/NGS580-nf: adding detected 'latest' among 1 records: msisensor-0.2 from 2018-03-16T10:01:12.163Z
69/2910 psychoinformatics-de/datalad: adding detected 'latest' among 1 records: fullmaster from 2018-03-17T11:48:03.403Z
70/2910 pranithavangala/singularity: adding detected 'latest' among 3 records: 0_part1 from 2021-03-16T15:48:20.933Z
71/2910 marcc-hpc/openmono: adding detected 'latest' among 1 records: 5.8.0.127 from 2018-03-19T17:39:30.918Z
72/2910 lkmokadam/singularity_images: adding detected 'latest' among 1 records: tensorflow_horovod from 2018-03-20T18:41:47.106Z
73/2910 ResearchIT/spack-singularity: adding detected 'latest' among 2 records: openmpi from 2021-04-19T20:49:05.714Z
74/2910 alexiswl/singularity: adding detected 'latest' among 1 records: nanopolish from 2018-03-26T10:14:22.756Z
75/2910 natacha-beck/containers: adding detected 'latest' among 3 records: fsl-5 from 2018-08-09T15:28:12.807Z
76/2910 CompBio-TDU-Japan/containers: adding detected 'latest' among 10 records: samtools from 2021-03-10T22:36:11.933Z
77/2910 ucr-singularity/ml-software: adding detected 'latest' among 4 records: tf1.8 from 2018-11-12T16:21:13.702Z
78/2910 MPIB/singularity-fsl: adding detected 'latest' among 10 records: 6.0.3 from 2021-03-30T03:54:55.581Z
79/2910 aizjForever/darch_recipe: adding detected 'latest' among 2 records: darch_build_nongpu from 2018-06-05T19:17:38.169Z
80/2910 neurodebian/dcm2niix: adding detected 'latest' among 1 records: debian-unstable-i386 from 2018-04-03T16:39:16.654Z
81/2910 maflister/surpi: adding detected 'latest' among 1 records: 1.0.18 from 2018-04-03T19:57:11.411Z
82/2910 jgrn307/pronghorn-singularity: adding detected 'latest' among 1 records: first from 2018-04-03T19:57:12.011Z
83/2910 lohanisa/pronghorn-singularity: adding detected 'latest' among 1 records: first from 2018-04-03T19:57:12.074Z
84/2910 annack84/pronghorn-singularity: adding detected 'latest' among 1 records: first from 2018-04-03T19:57:12.040Z
85/2910 houzhengyang/PronghornSingularity: adding detected 'latest' among 1 records: first from 2018-04-03T19:57:12.024Z
86/2910 aparrar1/pronghorn-singularity: adding detected 'latest' among 1 records: first from 2018-04-03T19:57:12.060Z
87/2910 ISUGIFsingularity/genomeModules: adding detected 'latest' among 1 records: 1.0.2 from 2020-07-15T16:44:45.941Z
88/2910 ISUGIFsingularity/utilities: adding detected 'latest' among 1 records: 1.0.1 from 2021-04-05T08:56:48.625Z
89/2910 natacha-beck/Mfannot: adding detected 'latest' among 1 records: v1.0 from 2019-10-25T12:50:03.997Z
90/2910 TMCantwell/CNN_container: adding detected 'latest' among 3 records: v1.4 from 2018-08-28T16:37:57.475Z
91/2910 bud42/RSFC_CONN: adding detected 'latest' among 1 records: v1.0.0 from 2018-04-11T17:52:05.241Z
92/2910 electronioncollider/jleic: adding detected 'latest' among 5 records: 1.0.4 from 2018-05-30T12:30:55.955Z
93/2910 electronioncollider/jleicgx: adding detected 'latest' among 1 records: 0.0.0 from 2018-04-13T04:44:05.148Z
94/2910 electronioncollider/eicroot: adding detected 'latest' among 1 records: v00.0 from 2018-04-13T04:44:05.162Z
95/2910 ShaopengLiu1/ATAC-seq_QC_analysis: adding detected 'latest' among 1 records: mm10 from 2018-04-13T04:44:02.414Z
96/2910 CAIsr/optimizing_exercise: adding detected 'latest' among 1 records: ashs from 2018-04-13T06:50:44.724Z
97/2910 bouthilx/qtrack: adding detected 'latest' among 4 records: 61064c1 from 2018-04-23T19:13:10.338Z
98/2910 bouthilx/flow: adding detected 'latest' among 4 records: pytorch.1.0.0 from 2019-11-25T19:57:50.607Z
99/2910 ipelupessy/amuse-singularity: adding detected 'latest' among 1 records: 42.3 from 2018-04-20T05:38:16.608Z
100/2910 maflister/digits: adding detected 'latest' among 1 records: 6.1.1 from 2019-08-26T18:12:12.105Z
101/2910 bermanmaxim/torch-gpu-singularity: adding detected 'latest' among 1 records: 390-48 from 2018-04-20T11:21:32.387Z
102/2910 arccontainers/recipes: adding detected 'latest' among 1 records: r_sf from 2018-04-20T16:55:26.693Z
103/2910 khanlab/tar2bids: adding detected 'latest' among 13 records: 0.0.2d from 2020-02-11T10:50:41.673Z
104/2910 AlanKuurstra/qsm_sstv: adding detected 'latest' among 2 records: v0.1.1 from 2019-12-08T19:49:43.648Z
105/2910 scleveland/qiime2-singularity: adding detected 'latest' among 5 records: 2019.7 from 2020-03-04T07:54:49.758Z
106/2910 granek/R24: adding detected 'latest' among 2 records: qiime2 from 2018-05-25T02:19:39.040Z
107/2910 bbrito/singularity_images: adding detected 'latest' among 6 records: 2.0 from 2018-10-15T17:10:04.000Z
108/2910 fenz/singularity-images: adding detected 'latest' among 2 records: ubuntu from 2019-08-19T12:57:14.810Z
109/2910 gnperdue/singularity_imgs: adding detected 'latest' among 9 records: py3_trch from 2020-07-20T19:46:53.928Z
110/2910 chriswier/borg-singularity: adding detected 'latest' among 1 records: tensorflow from 2018-05-11T08:00:01.510Z
111/2910 TomHarrop/singularity-containers: adding detected 'latest' among 90 records: bioconductor_3.9 from 2021-04-19T08:34:51.273Z
112/2910 granek/crne_transposon: adding detected 'latest' among 2 records: rstudio from 2018-12-03T09:49:39.785Z
113/2910 MSO4SC/Singularity: adding detected 'latest' among 1 records: ring_1.10.7 from 2019-11-20T17:45:28.956Z
114/2910 CHRUdeLille/vep_containers: adding detected 'latest' among 3 records: 75 from 2018-08-23T18:25:58.967Z
115/2910 khanlab/prepT2space: adding detected 'latest' among 12 records: v0.0.2b from 2020-06-05T15:26:31.750Z
116/2910 datalad/datalad-container: adding detected 'latest' among 1 records: testhelper from 2021-04-02T14:44:30.369Z
117/2910 mih/ohbm2018-training: adding detected 'latest' among 2 records: fsl from 2021-01-29T08:26:01.839Z
118/2910 CHRUdeLille/bedtools: adding detected 'latest' among 1 records: 2.27.1 from 2020-06-04T09:03:08.747Z
119/2910 gearslaboratory/gears-singularity: adding detected 'latest' among 11 records: gears-general from 2020-08-03T05:23:47.014Z
120/2910 JeffersonLab/jlabce: adding detected 'latest' among 3 records: 2.2 from 2019-12-13T00:25:18.140Z
121/2910 gearslaboratory/gears-singularity-private: adding detected 'latest' among 1 records: slurm from 2018-05-23T17:28:03.967Z
122/2910 d-w-moore/singularity-python-irodsclient: adding detected 'latest' among 1 records: prc-0_8_0 from 2018-06-28T16:08:29.860Z
123/2910 anushree85/singularity_imgs: adding detected 'latest' among 6 records: larcv_ws from 2018-08-19T21:19:46.821Z
124/2910 ResearchIT/eman2: adding detected 'latest' among 1 records: 21a from 2018-05-30T12:30:56.018Z
125/2910 khanlab/prepdwi: adding detected 'latest' among 8 records: v0.0.9 from 2020-03-30T19:38:27.388Z
126/2910 bioinfo-dirty-jobs/oncotator_singularity: adding detected 'latest' among 1 records: test from 2018-06-01T15:01:20.916Z
127/2910 Martybird/7TBEaST: adding detected 'latest' among 1 records: v0.0.1a from 2018-06-07T10:20:39.587Z
128/2910 houzhengyang/gears-singularity: adding detected 'latest' among 3 records: gears-treeseg-burt from 2018-06-08T05:56:44.723Z
129/2910 cngrid/hpc-container: adding detected 'latest' among 1 records: centos from 2018-06-08T16:24:59.637Z
130/2910 ReproNim/ohbm2018-training: adding detected 'latest' among 4 records: heudiconvn from 2021-04-08T01:20:48.520Z
131/2910 myyoda/ohbm2018-training: adding detected 'latest' among 4 records: heudiconv from 2018-06-11T04:54:30.268Z
132/2910 adam2392/deeplearning_hubs: adding detected 'latest' among 3 records: tvb from 2019-08-14T22:45:41.212Z
133/2910 dominik-handler/AP_singu: adding detected 'latest' among 49 records: purge_haplotigs from 2021-03-25T16:25:37.727Z
134/2910 natacha-beck/imputePrepSanger: adding detected 'latest' among 3 records: imputeprepsanger_v1.0 from 2018-09-10T04:18:51.816Z
135/2910 iqbal-lab-org/Mykrobe_tb_workflow: adding detected 'latest' among 1 records: tb from 2019-10-21T08:55:43.194Z
136/2910 ISUGIFsingularity/snpPhylo: adding detected 'latest' among 1 records: 1.0.0 from 2018-06-20T16:42:28.197Z
137/2910 bud42/FS6: adding detected 'latest' among 5 records: v1.2.3 from 2018-12-12T16:57:46.210Z
138/2910 natacha-beck/cbrain-containers-recipes: adding detected 'latest' among 6 records: ants_v2.1.0-ggit-n from 2018-06-26T19:08:46.249Z
139/2910 aces/cbrain-containers-recipes: adding detected 'latest' among 7 records: fsl_v6.0.1 from 2021-04-13T19:13:26.380Z
140/2910 bpow/bioinfo-containers: adding detected 'latest' among 2 records: debian from 2019-10-03T19:14:20.162Z
141/2910 mikemhenry/cme-lab-images: adding detected 'latest' among 6 records: mbuild from 2018-07-06T23:39:12.192Z
142/2910 overcookedfrog/novocraft: adding detected 'latest' among 1 records: 3.09.00 from 2018-07-02T14:24:04.318Z
143/2910 overcookedfrog/gatk3: adding detected 'latest' among 2 records: 3.7 from 2021-03-10T16:55:53.140Z
144/2910 overcookedfrog/vep: adding detected 'latest' among 1 records: 91.1 from 2018-07-02T14:24:04.360Z
145/2910 overcookedfrog/star: adding detected 'latest' among 1 records: 2.6.0c from 2018-07-02T14:24:04.370Z
146/2910 overcookedfrog/fastqstats: adding detected 'latest' among 1 records: 1.0.1 from 2018-07-02T14:24:04.380Z
147/2910 overcookedfrog/dplexstats: adding detected 'latest' among 1 records: 1.0.3 from 2018-07-02T14:24:04.389Z
148/2910 overcookedfrog/filtercanvasvcf: adding detected 'latest' among 1 records: 1.0 from 2018-07-02T14:24:04.399Z
149/2910 overcookedfrog/varkit: adding detected 'latest' among 1 records: 1.0.1 from 2018-07-02T14:24:04.409Z
150/2910 overcookedfrog/tumour-normal-enrichment: adding detected 'latest' among 1 records: 1.0.4 from 2018-07-02T14:24:04.419Z
151/2910 overcookedfrog/collate-rna-counts: adding detected 'latest' among 1 records: 1.0.1 from 2018-07-02T14:24:04.430Z
152/2910 overcookedfrog/bcl2fastq2: adding detected 'latest' among 1 records: 2.20.0.422 from 2020-08-04T06:54:42.135Z
153/2910 SupercomputingWales/singularity_hub: adding detected 'latest' among 31 records: deeplabcut_cpu from 2021-04-18T20:04:20.946Z
154/2910 ResearchIT/singularity-keras: adding detected 'latest' among 3 records: 2 from 2018-07-18T23:19:18.884Z
155/2910 bud42/RWML: adding detected 'latest' among 2 records: v1.0.1 from 2018-12-04T16:31:40.210Z
156/2910 marcc-hpc/julia: adding detected 'latest' among 4 records: 1.0.2 from 2019-12-13T04:40:43.683Z
157/2910 TMCantwell/pulsar_timing_containers: adding detected 'latest' among 3 records: pulsar.v1.3 from 2018-08-31T03:21:34.930Z
158/2910 federatedcloud/NixTemplates: adding detected 'latest' among 8 records: nix_alpine_base_82b5d9a742ad593a353f6160bce846227a0f4e4d from 2020-11-30T22:04:35.320Z
159/2910 natacha-beck/R_biocLite_container: adding detected 'latest' among 1 records: r_bioclite_v3.2 from 2018-07-10T19:29:39.798Z
160/2910 bud42/TRACULA: adding detected 'latest' among 2 records: v2.1.1 from 2018-12-14T05:20:13.621Z
161/2910 natacha-beck/pcev_pipelineCBRAIN: adding detected 'latest' among 1 records: pcev_v0.1 from 2018-07-11T01:44:04.439Z
162/2910 outbackCrustacian/mvapichtestingapp: adding detected 'latest' among 1 records: derived from 2020-04-25T05:34:10.086Z
163/2910 outbackCrustacian/install_MPI_to_Vagrant: adding detected 'latest' among 1 records: derived from 2018-07-13T21:19:59.938Z
164/2910 mcw-rcc/pytorch: adding detected 'latest' among 6 records: 1.2.0 from 2020-06-08T21:32:21.239Z
165/2910 mcw-rcc/rstudio-server: adding detected 'latest' among 5 records: 1.2.5042 from 2020-07-09T18:15:01.053Z
166/2910 mcw-rcc/rstudio: adding detected 'latest' among 3 records: 1.1.456 from 2020-09-22T17:05:11.509Z
167/2910 CAIsr/caid: adding detected 'latest' among 3 records: fsl_5p0p11 from 2018-07-13T21:19:59.011Z
168/2910 overcookedfrog/conpair: adding detected 'latest' among 1 records: 0.2 from 2018-07-16T12:37:00.098Z
169/2910 rmcolq/pandora: adding detected 'latest' among 5 records: pandora from 2020-11-19T12:40:23.384Z
170/2910 MarissaLL/singularity-containers: adding detected 'latest' among 16 records: longshot from 2021-04-14T04:30:31.054Z
171/2910 ffineis/nurcs-singularity: adding detected 'latest' among 6 records: biobakery from 2020-03-02T18:16:53.598Z
172/2910 rmcolq/Singularity_recipes: adding detected 'latest' among 12 records: snippy from 2020-07-15T12:38:05.337Z
173/2910 myNameIsPatrick/idq-services: adding detected 'latest' among 4 records: zookeeper-cp from 2018-07-24T21:22:23.431Z
174/2910 mcw-rcc/shiny-server: adding detected 'latest' among 2 records: 1.5.9.923 from 2021-04-03T23:27:52.705Z
175/2910 mlampros/singularity_containers: adding detected 'latest' among 6 records: rgf_r from 2020-04-03T08:39:43.989Z
176/2910 staeglis/HPOlib2: adding detected 'latest' among 11 records: convolutionalneuralnetworkoncifar10 from 2021-03-01T15:17:47.907Z
177/2910 jhamer90811/singularity_imgs: adding detected 'latest' among 1 records: ubuntu16.04-network_topology2 from 2018-08-08T16:16:09.162Z
178/2910 idot/Singularity_recipes: adding detected 'latest' among 8 records: albacore from 2018-07-31T15:32:55.898Z
179/2910 outbackCrustacian/python_singularity_recipes: adding detected 'latest' among 4 records: graphing from 2018-08-13T19:33:55.556Z
180/2910 ArbinTimilsina/Base-Singularity: adding detected 'latest' among 2 records: deeplearningwithprotodune from 2019-01-24T13:54:59.083Z
181/2910 tjhendrickson/BIDShcppipelines: adding detected 'latest' among 1 records: dev_v3.27.0 from 2018-08-02T22:57:26.915Z
182/2910 seyitkale/gromacs: adding detected 'latest' among 2 records: cent7 from 2018-08-04T22:20:18.799Z
183/2910 Characterisation-Virtual-Laboratory/CharacterisationVL-Software: adding detected 'latest' among 81 records: 1804 from 2021-04-06T11:03:51.500Z
184/2910 cottersci/DIRT2_Workflows: adding detected 'latest' among 1 records: dirt2d from 2020-05-27T04:25:53.306Z
185/2910 ECR-Cluster/tensor-comprehensions: adding detected 'latest' among 1 records: xenial-cuda9.0-cudnn7.0 from 2018-08-11T10:39:25.020Z
186/2910 omento/singularity: adding detected 'latest' among 2 records: bionic from 2018-08-16T17:20:05.721Z
187/2910 ebioman/SmrtLinkSingularity: adding detected 'latest' among 3 records: falconunzip from 2018-08-17T18:19:56.386Z
188/2910 sjmielke/singularity-recipes: adding detected 'latest' among 1 records: 0.4.1 from 2018-08-15T09:33:42.902Z
189/2910 aeneas-wp3/use-case-3: adding detected 'latest' among 1 records: version1 from 2018-08-19T16:01:34.760Z
190/2910 LSSTDESC/drp-stack: adding detected 'latest' among 2 records: drp from 2018-09-14T11:36:51.601Z
191/2910 whit2333/topside_containers: adding detected 'latest' among 1 records: topside from 2018-08-24T05:04:46.892Z
192/2910 muhammadzaheer/singularity-recipes: adding detected 'latest' among 8 records: selectivedynagpu from 2019-10-22T22:24:04.622Z
193/2910 MPIB/singularity-mriqc: adding detected 'latest' among 3 records: 0.14.2 from 2019-12-18T19:14:37.635Z
194/2910 jpetucci/fmriprep_icsaci: adding detected 'latest' among 1 records: rec from 2020-02-07T18:58:04.579Z
195/2910 DeepLearnPhysics/playground-singularity: adding detected 'latest' among 4 records: ub16.04-step3 from 2018-09-02T17:27:42.361Z
196/2910 UCL-RITS/rcps-shub-recipes: adding detected 'latest' among 2 records: qut from 2020-11-06T12:57:32.854Z
197/2910 dynverse/dynwrap: adding detected 'latest' among 4 records: bioc from 2019-03-28T15:14:02.974Z
198/2910 dynverse/dynwrap_tester: adding detected 'latest' among 8 records: r_dynwrap from 2018-10-29T20:59:11.208Z
199/2910 kkleinoros/imputePrepSanger: adding detected 'latest' among 2 records: imputeprepsanger_v1.0 from 2018-08-30T10:21:13.089Z
200/2910 aghozlane/Let-it-bin: adding detected 'latest' among 2 records: trimming from 2018-08-30T14:39:44.328Z
201/2910 magland/ml_ephys: adding detected 'latest' among 3 records: v0.2.5 from 2021-04-15T20:11:03.900Z
202/2910 mcw-rcc/qiime2: adding detected 'latest' among 3 records: 2019.1 from 2020-03-06T12:26:31.495Z
203/2910 magland/ml_ms4alg: adding detected 'latest' among 1 records: v0.1.4 from 2021-04-15T20:12:50.155Z
204/2910 magland/ml_pyms: adding detected 'latest' among 1 records: v0.0.1 from 2018-08-31T03:21:36.705Z
205/2910 magland/ml_ms3: adding detected 'latest' among 1 records: v0.0.2 from 2021-04-15T20:13:26.489Z
206/2910 BFL-lab/Mfannot: adding detected 'latest' among 2 records: v1.1 from 2020-10-29T21:39:53.001Z
207/2910 QuentinLetourneur/Let-it-bin: adding detected 'latest' among 15 records: trimming from 2019-12-06T17:28:44.738Z
208/2910 bouthilx/sgd-space-hub: adding detected 'latest' among 66 records: 4d4990a from 2018-10-22T21:27:18.806Z
209/2910 ii-bioinfo/ii-chipseq: adding detected 'latest' among 4 records: 0.2dev from 2019-01-07T17:57:02.774Z
210/2910 GreenwoodLab/imputePrepSanger: adding detected 'latest' among 3 records: imputeprepsanger_v1.0 from 2020-10-27T02:24:15.023Z
211/2910 GreenwoodLab/pcev_pipelineCBRAIN: adding detected 'latest' among 2 records: pcev_v1.0 from 2021-03-12T01:20:39.715Z
212/2910 magland/ml_spyking_circus: adding detected 'latest' among 3 records: v0.1.5 from 2018-09-08T21:55:12.947Z
213/2910 bballew/NGS_singularity_recipes: adding detected 'latest' among 13 records: picard_2-18-15 from 2021-03-04T18:06:30.289Z
214/2910 khanlab/diffparc-sumo: adding detected 'latest' among 3 records: v0.0.2 from 2018-12-10T20:17:25.408Z
215/2910 patrickvdb/RNAseq_tools: adding detected 'latest' among 2 records: v1.0 from 2018-10-09T10:11:50.126Z
216/2910 natacha-beck/methylation450KPipeline: adding detected 'latest' among 1 records: methylation450kpipeline_v1.0 from 2018-09-12T19:58:35.161Z
217/2910 mcw-rcc/anvio: adding detected 'latest' among 2 records: 5.2 from 2019-12-13T08:22:37.887Z
218/2910 schmiph2/keras-jupyter-singularity: adding detected 'latest' among 1 records: keras-py3 from 2021-04-13T14:00:46.645Z
219/2910 GreenwoodLab/methylation450KPipeline: adding detected 'latest' among 1 records: methylation450kpipeline_v1.0 from 2018-09-13T21:15:39.208Z
220/2910 ii-bioinfo/iiGenomes-build: adding detected 'latest' among 1 records: 0.1 from 2018-10-30T12:35:59.845Z
221/2910 mcw-rcc/r-base: adding detected 'latest' among 5 records: 3.5.1 from 2021-02-26T05:52:14.961Z
222/2910 bergeto1/Test5PhytonOSimage: adding detected 'latest' among 1 records: keras-py3 from 2018-09-21T13:10:13.153Z
223/2910 mcw-rcc/geant4: adding detected 'latest' among 1 records: 4.10.4 from 2020-10-02T17:44:12.696Z
224/2910 magland/MEArec: adding detected 'latest' among 2 records: v0.1.0 from 2018-09-26T15:44:58.301Z
225/2910 magland/ml_mearec: adding detected 'latest' among 1 records: v0.1.5 from 2018-09-28T13:34:14.495Z
226/2910 intel/HPC-containers-from-Intel: adding detected 'latest' among 1 records: lammps from 2020-12-23T08:18:22.251Z
227/2910 psychoinformatics-de/cbbs-toolbox: adding detected 'latest' among 3 records: fsl from 2018-12-14T10:38:28.275Z
228/2910 pescobar/nace-container: adding detected 'latest' among 1 records: 0.1 from 2018-10-03T09:11:43.240Z
229/2910 keceli/container_nwchem: adding detected 'latest' among 3 records: mpich from 2018-10-03T03:26:38.352Z
230/2910 dfernandezperez/bioinformatics-singularity: adding detected 'latest' among 3 records: chipseq from 2019-05-17T20:05:25.822Z
231/2910 FloFlo93/PICA-to-go: adding detected 'latest' among 1 records: 1.1.0 from 2019-07-27T18:17:10.045Z
232/2910 mcw-rcc/fmriprep: adding detected 'latest' among 1 records: 1.1.8 from 2018-10-09T17:49:31.723Z
233/2910 bahlolab/nf-wgs-multiqc: adding detected 'latest' among 3 records: v0.2 from 2018-10-11T09:24:02.674Z
234/2910 Amjadhpc/PHEnix: adding detected 'latest' among 1 records: 6.0 from 2018-10-16T23:20:50.042Z
235/2910 schluenz/calipsoplus: adding detected 'latest' among 2 records: pymca from 2018-10-23T17:47:48.202Z
236/2910 HugoMananet/Samtools: adding detected 'latest' among 2 records: samtools.1.9.def from 2018-12-03T17:26:31.312Z
237/2910 BUBioinformaticsHub/bubhub-singularity-apps: adding detected 'latest' among 1 records: template from 2018-10-16T23:20:50.103Z
238/2910 HugoMananet/RTG-Tools: adding detected 'latest' among 1 records: 3.9.1 from 2018-10-18T10:53:34.330Z
239/2910 ii-bioinfo/dialign2: adding detected 'latest' among 1 records: 2.2.1 from 2018-10-18T17:22:06.231Z
240/2910 nuitrcs/tesseract: adding detected 'latest' among 1 records: v400-beta from 2018-10-19T18:21:08.392Z
241/2910 frankieliu/srecipe: adding detected 'latest' among 1 records: vscode from 2018-10-20T20:47:32.375Z
242/2910 baxpr/mp2rage: adding detected 'latest' among 3 records: v2.1.0 from 2021-04-12T13:36:10.533Z
243/2910 baxpr/fmri_conncalc: adding detected 'latest' among 1 records: v1.0.0 from 2018-10-24T18:39:33.700Z
244/2910 drskrs/sng-intermediates: adding detected 'latest' among 1 records: centos7 from 2018-10-25T18:55:06.202Z
245/2910 baxpr/fmri_modularity: adding detected 'latest' among 1 records: v1.0.0 from 2018-10-26T11:06:03.712Z
246/2910 ISUGIFsingularity/masurca: adding detected 'latest' among 2 records: 1.0.0 from 2021-04-16T05:49:03.477Z
247/2910 oliviermattelaer/singularity-recipe: adding detected 'latest' among 4 records: mg5_ma5_py8 from 2020-10-08T16:24:35.140Z
248/2910 langmead-lab/recount-pump: adding detected 'latest' among 3 records: workflow_base from 2019-02-06T18:43:52.018Z
249/2910 baxpr/ndw_wm_edat: adding detected 'latest' among 1 records: v3.0.0 from 2018-11-01T03:16:09.017Z
250/2910 dmorrill10/research2018: adding detected 'latest' among 2 records: cpu from 2018-11-01T21:55:11.797Z
251/2910 magland/spikeforest: adding detected 'latest' among 2 records: v0.2.1 from 2018-11-07T20:20:33.875Z
252/2910 ii-bioinfo/ii-rnaseq: adding detected 'latest' among 3 records: 0.4 from 2019-09-23T12:12:25.091Z
253/2910 nelsonihc/singularity: adding detected 'latest' among 3 records: torch-1804 from 2019-02-13T20:23:56.833Z
254/2910 aeneas-wp3/use-case-2: adding detected 'latest' among 2 records: pulsar.gbncc from 2018-11-06T16:15:10.726Z
255/2910 chrarnold/Singularity_images: adding detected 'latest' among 10 records: difftf_conda from 2021-04-16T19:30:22.441Z
256/2910 CHRUdeLille/bcftools_containers: adding detected 'latest' among 1 records: 1.9 from 2019-11-20T07:57:49.592Z
257/2910 jtchilders/singularity_gpu_tensorflow: adding detected 'latest' among 1 records: mpich from 2018-11-07T13:35:08.002Z
258/2910 mcw-rcc/tensorflow: adding detected 'latest' among 3 records: 1.11-gpu from 2020-09-01T16:39:46.899Z
259/2910 AdinaWagner/BIDSsacc: adding detected 'latest' among 2 records: 1.1 from 2018-11-30T19:45:31.689Z
260/2910 bahlolab/nf-MPS-gatk-bp: adding detected 'latest' among 11 records: v1.6.2 from 2020-11-27T00:40:44.836Z
261/2910 qbicsoftware/qbic-singularity-rnaseqsamplesize: adding detected 'latest' among 2 records: 0.2.0 from 2018-11-12T19:45:45.239Z
262/2910 sbilge/ClinicalReportingPipeline: adding detected 'latest' among 1 records: filedeploy from 2018-11-19T13:45:58.794Z
263/2910 jpetucci/mriqc_icsaci: adding detected 'latest' among 1 records: rec from 2019-01-07T17:57:03.746Z
264/2910 patrickvdb/velocyto: adding detected 'latest' among 1 records: v0.17 from 2020-03-02T13:27:13.152Z
265/2910 ProKil/own-singularity: adding detected 'latest' among 1 records: 0.5.0 from 2019-10-20T04:18:46.125Z
266/2910 magland/sf_spyking_circus: adding detected 'latest' among 1 records: v0.1.0 from 2018-11-15T15:58:30.765Z
267/2910 apphys/hpsim_rl_singularity: adding detected 'latest' among 2 records: centos7-cuda-tf1.11.0-torch0.4.1 from 2018-11-16T01:38:15.819Z
268/2910 patrickvdb/knn_smoothing: adding detected 'latest' among 1 records: v2.1 from 2018-11-16T13:28:05.928Z
269/2910 CHRUdeLille/bcl2fastq2_containers: adding detected 'latest' among 1 records: 2.20.0.422 from 2018-11-20T17:27:30.328Z
270/2910 datalad/datalad: adding detected 'latest' among 4 records: 0.11.x from 2020-08-21T17:49:59.656Z
271/2910 happinesszl/pytorch: adding detected 'latest' among 1 records: 0.4.1-cuda9-cudnn7-devel from 2018-11-24T04:49:43.457Z
272/2910 craig-willis/terraref-singularity: adding detected 'latest' among 1 records: def from 2018-11-22T17:35:50.418Z
273/2910 TMCantwell/AENEAS-use-case-Image-based-Object-Detection-Classification: adding detected 'latest' among 1 records: usecase4 from 2019-04-02T15:49:00.332Z
274/2910 happinesszl/tensorflow: adding detected 'latest' among 1 records: 1.12.0-devel from 2018-11-26T17:12:55.581Z
275/2910 bmichanderson/singularity-containers: adding detected 'latest' among 5 records: kat from 2021-04-06T11:13:12.547Z
276/2910 HugoMananet/OutLyzer: adding detected 'latest' among 2 records: outlyzer.2.0.def from 2018-12-03T17:26:31.917Z
277/2910 HugoMananet/Gemini: adding detected 'latest' among 1 records: gemini.0.20.1.def from 2018-12-21T17:01:17.137Z
278/2910 HugoMananet/VarScan: adding detected 'latest' among 2 records: varscan.2.4.2 from 2018-12-03T17:26:31.297Z
279/2910 HugoMananet/GATK: adding detected 'latest' among 2 records: gatk.4.0.11.0.def from 2018-12-03T12:59:07.859Z
280/2910 bcdarwin/minc-toolkit-containers: adding detected 'latest' among 2 records: base from 2018-12-01T16:42:26.399Z
281/2910 baxpr/freesurfer-singularity: adding detected 'latest' among 2 records: dev2 from 2021-02-27T15:23:17.116Z
282/2910 Fan-Luo/HPC: adding detected 'latest' among 2 records: dynet from 2018-12-09T13:14:44.264Z
283/2910 SKA-INAF/caesar-singularity: adding detected 'latest' among 1 records: xenial from 2020-10-08T08:34:23.826Z
284/2910 magao-x/krank: adding detected 'latest' among 1 records: def from 2018-12-10T06:45:59.799Z
285/2910 HugoMananet/HLAminer: adding detected 'latest' among 1 records: hlaminer.1.4.def from 2018-12-21T17:01:17.099Z
286/2910 baxpr/nirsqa: adding detected 'latest' among 1 records: v3.0.0 from 2021-02-17T17:37:10.806Z
287/2910 bouthilx/repro-hub: adding detected 'latest' among 51 records: 88dc91b from 2019-05-06T15:37:41.443Z
288/2910 coreyjadams/larcv2-singularity: adding detected 'latest' among 12 records: centos7-cuda-torch-mpich from 2020-03-03T18:04:42.735Z
289/2910 aeneas-wp3/use-case-4: adding detected 'latest' among 1 records: usecase4 from 2019-02-26T20:10:22.966Z
290/2910 yarikoptic/mrtrix3: adding detected 'latest' among 2 records: debian-dev-unstable-amd64 from 2018-12-17T16:03:53.123Z
291/2910 garfinjm/singularity-seqsero2: adding detected 'latest' among 1 records: 0.1.0 from 2018-12-17T20:48:09.750Z
292/2910 ISU-HPC/cDNA_cupcake: adding detected 'latest' among 1 records: 5.8.0 from 2018-12-18T23:11:37.990Z
293/2910 akashsingularityucr/ml-software: adding detected 'latest' among 4 records: tf1.8 from 2018-12-24T04:53:14.111Z
294/2910 ramankarthik15/containers: adding detected 'latest' among 1 records: stream from 2018-12-29T03:55:59.369Z
295/2910 GregoryAshton/TestBilbySingularity: adding detected 'latest' among 3 records: psrchive from 2019-01-08T15:14:13.355Z
296/2910 aminnayebi/Py2.7Torch-Container: adding detected 'latest' among 3 records: cen7py2-7 from 2019-01-31T04:31:41.316Z
297/2910 lscsoft/bilby: adding detected 'latest' among 4 records: 0.3.6 from 2020-12-06T04:24:40.090Z
298/2910 byee4/singularity: adding detected 'latest' among 7 records: monocle from 2019-01-14T21:19:29.844Z
299/2910 lscsoft/bilby_pipe: adding detected 'latest' among 5 records: 0.0.3 from 2020-01-24T17:33:57.476Z
300/2910 nguyemi5/vir-lift: adding detected 'latest' among 2 records: kinetic from 2019-01-04T07:48:36.727Z
301/2910 mcw-meier-lab/Singularity: adding detected 'latest' among 4 records: freesurfer6 from 2019-04-16T01:22:32.919Z
302/2910 bahlolab/nf-pacbio-amplicon-analysis: adding detected 'latest' among 17 records: r_v0.5 from 2021-03-31T06:21:36.562Z
303/2910 GregoryAshton/containers: adding detected 'latest' among 3 records: psrchive from 2021-02-23T16:43:43.843Z
304/2910 bhattlab/wits_workshop: adding detected 'latest' among 1 records: classification from 2019-01-11T15:17:05.162Z
305/2910 jpetucci/octave_icsaci: adding detected 'latest' among 1 records: def from 2019-01-14T21:19:29.958Z
306/2910 feilong/neurodebian_singularity: adding detected 'latest' among 1 records: beaver_2019-01-14 from 2019-01-14T23:12:35.723Z
307/2910 linzhi2013/MitoZ: adding detected 'latest' among 4 records: v2.4-alpha from 2021-04-13T17:51:56.193Z
308/2910 keceli/ffn: adding detected 'latest' among 4 records: tf1.12 from 2019-06-06T09:15:15.412Z
309/2910 qbicsoftware/rnaseq-power-cli: adding detected 'latest' among 3 records: 0.3.0 from 2019-07-02T23:19:19.133Z
310/2910 baxpr/gradtensor: adding detected 'latest' among 1 records: v1.0.0 from 2019-08-31T01:11:46.744Z
311/2910 GuanJ-H/octave_icsaci: adding detected 'latest' among 7 records: def from 2019-04-16T15:52:00.111Z
312/2910 baxpr/example-spm-singularity-spider: adding detected 'latest' among 1 records: v1.0.0 from 2019-01-20T13:44:22.526Z
313/2910 jiyeonhan/singularity_imgs: adding detected 'latest' among 1 records: py2_tf17 from 2019-01-21T15:26:42.082Z
314/2910 shaheenkdr/IndianASR: adding detected 'latest' among 3 records: paddle_deepspeech from 2019-04-24T14:27:17.551Z
315/2910 dp2ski/genome_software_aci: adding detected 'latest' among 1 records: rec from 2019-02-05T16:48:48.026Z
316/2910 dp2ski/openpose_aci: adding detected 'latest' among 1 records: rec from 2019-12-23T19:18:40.088Z
317/2910 IvayloStoimenov/Singa: adding detected 'latest' among 1 records: hh from 2019-01-26T22:48:03.042Z
318/2910 ertheisen/appalachian_centos: adding detected 'latest' among 1 records: hg19v1.centos from 2019-03-01T19:49:13.110Z
319/2910 ertheisen/cloudsrest_centos: adding detected 'latest' among 1 records: hg19v1.centos from 2019-06-14T18:25:03.475Z
320/2910 DeepLearnPhysics/larcv2-singularity: adding detected 'latest' among 14 records: ub18.04-gpu-ana0-ml-larcv2 from 2020-09-25T04:46:57.565Z
321/2910 GuanJ-H/booster_icsaci: adding detected 'latest' among 1 records: rec from 2019-01-26T22:48:03.214Z
322/2910 jshede32/Singularity: adding detected 'latest' among 1 records: yolo from 2019-01-26T22:48:03.223Z
323/2910 bhaveshshrimali/singularityFiredrake: adding detected 'latest' among 1 records: recipe from 2019-10-22T20:02:21.038Z
324/2910 arcsUVA/singularity-scripts: adding detected 'latest' among 5 records: tensorflow-1.12.0-py27 from 2019-01-28T22:35:36.583Z
325/2910 arcsUVA/tensorflow: adding detected 'latest' among 6 records: 1.14.0-py36 from 2020-05-14T00:29:48.139Z
326/2910 ertheisen/southkaibab_centos: adding detected 'latest' among 1 records: hg19v1.centos from 2019-03-01T19:49:13.176Z
327/2910 QTIM-Lab/DeepNeuro: adding detected 'latest' among 4 records: deepneuro_skullstripping from 2019-06-15T07:05:38.171Z
328/2910 arcsUVA/anaconda: adding detected 'latest' among 2 records: cuda9.0-cudnn7.4-py3.6 from 2020-01-30T18:58:50.103Z
329/2910 jjhelmus/sample_singularity_containers: adding detected 'latest' among 5 records: cpu_27 from 2019-03-27T08:48:37.134Z
330/2910 dp2ski/trinity_aci: adding detected 'latest' among 1 records: rec from 2019-02-01T19:07:43.727Z
331/2910 arcsUVA/caffe2: adding detected 'latest' among 1 records: 0.8.0 from 2019-02-24T08:38:39.899Z
332/2910 baxpr/magm-normalize: adding detected 'latest' among 1 records: v3.0.0 from 2019-02-04T09:08:23.726Z
333/2910 arcsUVA/pytorch: adding detected 'latest' among 2 records: 1.3.1-py36 from 2020-02-18T19:54:04.866Z
334/2910 arcsUVA/cp-analyst: adding detected 'latest' among 1 records: 2.2.1 from 2019-02-04T16:33:11.315Z
335/2910 arcsUVA/hydrator: adding detected 'latest' among 1 records: 0.0.2 from 2019-02-04T16:33:11.332Z
336/2910 arcsUVA/inkscape: adding detected 'latest' among 1 records: 0.92.3 from 2019-02-04T16:33:11.342Z
337/2910 PersonalizedOncology/ClinVAP: adding detected 'latest' among 3 records: filedeploy from 2020-05-07T09:25:11.023Z
338/2910 jonmiller3/singularity_imgs: adding detected 'latest' among 4 records: larcv_fcaws from 2020-10-16T21:55:31.700Z
339/2910 connor-lab/singularity-recipes: adding detected 'latest' among 28 records: canu from 2021-02-16T02:45:34.861Z
340/2910 brucemoran/Singularity: adding detected 'latest' among 19 records: centos7-conda from 2021-03-31T00:16:13.573Z
341/2910 pmitev/Teoroo-singularity: adding detected 'latest' among 27 records: rstudio-server from 2021-03-02T17:58:46.382Z
342/2910 arcsUVA/cellprofiler: adding detected 'latest' among 2 records: 3.1.8 from 2020-06-16T23:23:59.119Z
343/2910 williamssanders/pepa: adding detected 'latest' among 4 records: pepa from 2020-03-24T17:30:55.088Z
344/2910 powerPlant/swan-srf: adding detected 'latest' among 1 records: 3516c2f from 2019-02-14T08:45:05.056Z
345/2910 whbrewer/hpccm-test: adding detected 'latest' among 1 records: centos from 2019-02-15T19:29:45.753Z
346/2910 ebothmann/sherpa-singularity: adding detected 'latest' among 14 records: rivet_centos6 from 2020-10-21T08:03:25.981Z
347/2910 hans/research-labs: adding detected 'latest' among 3 records: deepo-cpu-nlp from 2019-10-01T16:04:25.246Z
348/2910 CNC-UMCG/cnc_mriqc: adding detected 'latest' among 1 records: txt from 2019-02-21T12:58:53.369Z
349/2910 JFresnedo/AmpSeq: adding detected 'latest' among 1 records: ampseq from 2021-04-12T20:01:37.928Z
350/2910 sschmeier/simg-preprocess: adding detected 'latest' among 3 records: 201911 from 2020-11-01T12:44:39.614Z
351/2910 mbhall88/singularity_training: adding detected 'latest' among 1 records: fun from 2019-02-22T21:13:26.488Z
352/2910 sschmeier/simg-txid: adding detected 'latest' among 3 records: 201907 from 2020-11-01T08:55:01.612Z
353/2910 Amjadhpc/R-3.5.1: adding detected 'latest' among 1 records: def from 2019-07-27T00:03:58.473Z
354/2910 aertslab/pySCENIC: adding detected 'latest' among 7 records: 0.9.18 from 2021-04-16T09:27:45.942Z
355/2910 magoapu/sing_af: adding detected 'latest' among 1 records: ubuntu3 from 2019-02-25T16:42:17.560Z
356/2910 georgevanderson/SingularityTest: adding detected 'latest' among 1 records: testing from 2019-04-08T08:50:14.164Z
357/2910 vmichals/singularity: adding detected 'latest' among 10 records: miniconda from 2020-05-20T04:38:29.138Z
358/2910 m-novikov/singularity_training: adding detected 'latest' among 1 records: fun from 2019-02-27T18:33:23.067Z
359/2910 adamov-artem/singularity_training: adding detected 'latest' among 1 records: fun from 2019-02-27T18:33:23.302Z
360/2910 sudeepsahadevan/singulartiy_training: adding detected 'latest' among 1 records: fun from 2019-02-27T18:33:23.151Z
361/2910 ajank/singularity_training: adding detected 'latest' among 1 records: fun from 2019-02-27T18:33:23.292Z
362/2910 jakob-wirbel/singularity_training: adding detected 'latest' among 1 records: fun from 2019-02-27T18:33:23.110Z
363/2910 gtca/singularity_training: adding detected 'latest' among 1 records: fun from 2019-02-27T18:33:23.202Z
364/2910 mmarinriera/Singularity_training: adding detected 'latest' among 1 records: fun from 2019-02-27T18:33:23.262Z
365/2910 tsekara/singularity_training: adding detected 'latest' among 1 records: fun from 2019-02-27T18:33:23.161Z
366/2910 theavanrossum/singularity_training: adding detected 'latest' among 1 records: fun from 2019-02-27T18:33:23.131Z
367/2910 Distue/singularity_training: adding detected 'latest' among 1 records: fun from 2019-02-27T18:33:23.077Z
368/2910 irenedet/singularity_training: adding detected 'latest' among 1 records: fun from 2019-02-27T18:33:23.222Z
369/2910 mffrank/singularity_training: adding detected 'latest' among 1 records: fun from 2019-02-27T18:33:23.242Z
370/2910 hugocarlos/singularity_training: adding detected 'latest' among 1 records: fun from 2019-02-27T18:33:23.171Z
371/2910 OlgaSigalova/singularity_training: adding detected 'latest' among 1 records: fun from 2019-02-27T18:33:23.312Z
372/2910 grimbough/Testing-Singularity: adding detected 'latest' among 1 records: fun from 2019-02-27T18:33:23.322Z
373/2910 AnniekStok/singularity_training: adding detected 'latest' among 1 records: fun from 2019-02-27T18:33:23.181Z
374/2910 MarekWolczynski/singularity_training: adding detected 'latest' among 1 records: fun from 2019-02-27T18:33:23.192Z
375/2910 beatrizserrano/singularity_training: adding detected 'latest' among 1 records: fun from 2019-02-27T18:33:23.142Z
376/2910 tischi/singularity_training: adding detected 'latest' among 1 records: fun from 2019-02-27T18:33:23.212Z
377/2910 lysfyg/singularity_training: adding detected 'latest' among 1 records: fun from 2019-02-27T18:33:23.100Z
378/2910 jeongdo801/singularity_training: adding detected 'latest' among 1 records: fun from 2019-02-27T18:33:23.282Z
379/2910 Tom-TBT/singularity_training: adding detected 'latest' among 1 records: fun from 2019-02-27T18:33:23.232Z
380/2910 cgirardot/singularity_training: adding detected 'latest' among 1 records: fun from 2019-02-27T18:33:23.089Z
381/2910 YanPYuan/test12: adding detected 'latest' among 1 records: fun from 2019-02-27T18:33:23.272Z
382/2910 ndaga/singularity-training: adding detected 'latest' among 1 records: fun from 2019-02-27T18:33:23.332Z
383/2910 mhyfritz/singularity-training: adding detected 'latest' among 1 records: fun from 2019-02-27T18:33:23.343Z
384/2910 manasi-t24/singularity_recipes: adding detected 'latest' among 1 records: start from 2019-03-01T19:49:13.805Z
385/2910 mxmlnkn/shub-containers: adding detected 'latest' among 3 records: lbann-no-gpu from 2019-03-06T12:46:34.155Z
386/2910 GuanJ-H/Madagascar_icsaci: adding detected 'latest' among 1 records: rec from 2019-03-01T19:49:14.189Z
387/2910 jpetucci/abcd_hpc-icsaci: adding detected 'latest' among 1 records: rec from 2019-03-12T15:09:01.714Z
388/2910 giovannipizzi/singularity-quantum-espresso: adding detected 'latest' among 3 records: ansible-6.3 from 2020-04-28T08:35:36.747Z
389/2910 serbinsh/ctsm_containers: adding detected 'latest' among 2 records: release-clm5.0.15 from 2019-03-06T15:11:52.708Z
390/2910 aminnayebi/ContainerMOE: adding detected 'latest' among 3 records: ubuntumoe-xenial from 2019-03-12T08:04:35.663Z
391/2910 mrobbert/singularity_image_recipes: adding detected 'latest' among 1 records: hello_world from 2019-03-07T01:18:17.761Z
392/2910 jeffacce/singularity-ml-box: adding detected 'latest' among 2 records: ubuntu-bionic-cuda10 from 2019-09-25T04:31:35.290Z
393/2910 elimoss/metagenomics_workflows: adding detected 'latest' among 2 records: longread from 2020-02-17T09:32:48.598Z
394/2910 dp2ski/katydid_aci: adding detected 'latest' among 1 records: rec from 2019-03-13T03:34:54.408Z
395/2910 LArbys/larbys-containers: adding detected 'latest' among 1 records: ubdldev from 2019-03-13T03:34:54.636Z
396/2910 XeBoris/Singularity: adding detected 'latest' among 1 records: test1 from 2019-03-13T10:07:35.731Z
397/2910 dp2ski/abcd_aci: adding detected 'latest' among 1 records: rec from 2019-04-13T15:19:00.787Z
398/2910 sschmeier/simg-rnaseq: adding detected 'latest' among 5 records: 201907 from 2020-12-03T11:53:56.263Z
399/2910 kalibera/rchk: adding detected 'latest' among 2 records: def from 2021-01-29T17:06:18.731Z
400/2910 sbilge/ClinVAP: adding detected 'latest' among 2 records: filedeploy from 2019-10-15T17:06:57.996Z
401/2910 switt4/surfAnalysis: adding detected 'latest' among 2 records: 0.1 from 2019-03-20T08:24:17.205Z
402/2910 bhattlab/bhattlab_workflows: adding detected 'latest' among 2 records: plotting from 2021-04-14T03:38:36.691Z
403/2910 shelvia1039/Building_Image: adding detected 'latest' among 2 records: 1.12.0-devel-gpu from 2019-04-02T06:19:31.753Z
404/2910 JBCA-MachineLearning/GPUs: adding detected 'latest' among 1 records: cuda10 from 2019-10-09T14:50:44.021Z
405/2910 merckey/Singularity: adding detected 'latest' among 6 records: snakemake from 2019-06-23T23:32:47.644Z
406/2910 ARPA-SIMC/smnd: adding detected 'latest' among 2 records: smnd-run from 2020-10-29T16:22:59.445Z
407/2910 dp2ski/guppy_aci: adding detected 'latest' among 1 records: rec from 2019-03-21T18:05:58.244Z
408/2910 elimoss/lathe: adding detected 'latest' among 3 records: quickmerge from 2021-04-14T14:37:13.692Z
409/2910 williamssanders/sdaps: adding detected 'latest' among 1 records: sdaps from 2019-03-21T21:17:42.683Z
410/2910 ArjitM/CellMorphology: adding detected 'latest' among 2 records: cellprof2 from 2020-07-14T13:59:54.321Z
411/2910 mark-e-deyoung/afit_mlperf_training: adding detected 'latest' among 6 records: translation from 2020-05-06T17:54:26.367Z
412/2910 yarikoptic/demo-cifar-preproc: adding detected 'latest' among 1 records: preproc from 2019-07-19T15:20:10.282Z
413/2910 jtchilders/alcf_benchmarks: adding detected 'latest' among 6 records: datafiles_10k_1kb from 2019-04-08T19:28:24.218Z
414/2910 d-w-moore/new_d2c: adding detected 'latest' among 1 records: base-4.2.5 from 2019-03-27T08:48:37.842Z
415/2910 dp2ski/julia_aci: adding detected 'latest' among 1 records: rec from 2019-03-28T19:02:13.851Z
416/2910 pndni/centos7-base: adding detected 'latest' among 7 records: 1.0.0 from 2021-01-29T11:22:40.311Z
417/2910 bilgelm/tau_predictors_singularity_image: adding detected 'latest' among 1 records: nipyper from 2019-03-27T08:48:38.143Z
418/2910 ltalirz/singularity-recipe-zeopp: adding detected 'latest' among 1 records: ansible from 2019-10-08T18:37:30.597Z
419/2910 jshede32/singularity: adding detected 'latest' among 1 records: recipe from 2019-04-02T20:23:25.489Z
420/2910 jshede32/singularity-test: adding detected 'latest' among 1 records: recipe from 2019-03-28T19:02:13.907Z
421/2910 mcw-rcc/cadd: adding detected 'latest' among 1 records: 1.5 from 2019-03-29T19:18:16.702Z
422/2910 dtrahan41/another-test-container: adding detected 'latest' among 1 records: def from 2019-04-01T19:11:54.020Z
423/2910 vladGriguta/GPUs: adding detected 'latest' among 1 records: cuda10 from 2019-04-02T20:23:25.379Z
424/2910 pndni/FSL-and-freesurfer: adding detected 'latest' among 2 records: fsl-6.0.1_freesurfer-6.0.1_1.0.1 from 2021-03-29T19:30:50.984Z
425/2910 pndni/minc-container: adding detected 'latest' among 3 records: 1.3.0 from 2019-04-13T15:19:01.102Z
426/2910 pndni/dcm-conversion-container: adding detected 'latest' among 4 records: 4.0.0 from 2019-04-12T14:59:18.635Z
427/2910 switt4/SingularityTeaching: adding detected 'latest' among 1 records: 0.0 from 2019-04-04T07:45:35.650Z
428/2910 pndni/minc-and-ants-container: adding detected 'latest' among 3 records: 1.1.0 from 2019-04-13T15:19:01.112Z
429/2910 aparrar1/redis_image: adding detected 'latest' among 1 records: first from 2019-09-22T08:13:55.632Z
430/2910 arcsUVA/theano: adding detected 'latest' among 1 records: 1.0.4-py36 from 2019-04-05T22:25:26.949Z
431/2910 GuanJ-H/-udunits2-devel-: adding detected 'latest' among 4 records: def from 2019-04-09T19:13:42.415Z
432/2910 pndni/Charge_GM_WM_Properties_Pipeline: adding detected 'latest' among 5 records: dev from 2019-04-23T20:55:38.184Z
433/2910 ivana-m/singularity_image_recipes: adding detected 'latest' among 4 records: mpich33 from 2019-04-10T18:24:19.218Z
434/2910 pndni/freesurfer-6.0.1-container: adding detected 'latest' among 3 records: 1.1.0 from 2019-05-01T22:22:28.491Z
435/2910 iferres/Singularity_recipes: adding detected 'latest' among 7 records: pgap from 2020-10-19T08:34:46.683Z
436/2910 pndni/minc-ants-and-fsl-container: adding detected 'latest' among 2 records: 1.1.0 from 2019-04-13T15:19:01.419Z
437/2910 pndni/minc-ants-fsl-and-fs-container: adding detected 'latest' among 2 records: 1.1.0 from 2019-04-13T15:19:01.428Z
438/2910 fempar/fempar: adding detected 'latest' among 4 records: gnu-debug_p4est-serial from 2019-05-24T15:49:13.426Z
439/2910 pndni/development-image: adding detected 'latest' among 1 records: dev from 2019-04-13T15:19:00.989Z
440/2910 arcsUVA/omero-client: adding detected 'latest' among 1 records: 5.4.10 from 2020-05-01T18:29:36.072Z
441/2910 rearmstr/singularity_image_recipes: adding detected 'latest' among 2 records: mpich33 from 2019-04-17T14:28:05.119Z
442/2910 phelelani/transcriptomics: adding detected 'latest' among 1 records: r from 2020-02-12T21:23:08.125Z
443/2910 sjw42/mriqc_icsaci: adding detected 'latest' among 1 records: rec from 2019-11-30T00:54:18.538Z
444/2910 gaohao95/pocl-singularity: adding detected 'latest' among 1 records: def from 2019-04-18T21:44:23.951Z
445/2910 ReproNim/containers: adding detected 'latest' among 73 records: bids-pymvpa--2.0.2 from 2021-04-19T22:25:54.006Z
446/2910 alan0415/singularity_tf_rdma: adding detected 'latest' among 7 records: v8 from 2019-04-27T17:36:59.320Z
447/2910 sternacht/tf_singu: adding detected 'latest' among 8 records: va from 2019-07-02T13:32:17.023Z
448/2910 wkcwells/singularity: adding detected 'latest' among 1 records: chroma.chroma-docker from 2019-04-25T15:46:05.417Z
449/2910 SysBioChalmers/rnaseq: adding detected 'latest' among 1 records: hebbe from 2019-12-13T16:41:22.231Z
450/2910 kapsakcj/singularities: adding detected 'latest' among 5 records: seqsero2.1.0.0 from 2019-08-29T18:40:02.301Z
451/2910 alan0415/singularity_swift: adding detected 'latest' among 1 records: v1 from 2019-04-23T20:55:38.837Z
452/2910 rwblair/singularity_fmriprep: adding detected 'latest' among 3 records: 1.3.1.post1 from 2019-04-24T02:14:23.792Z
453/2910 team113sanger/t113-singularity: adding detected 'latest' among 16 records: fastqc__0.11.8__1 from 2020-02-11T11:52:37.895Z
454/2910 GuanJ-H/V8_icsaci: adding detected 'latest' among 3 records: def from 2019-04-25T15:46:05.854Z
455/2910 pndni/mriqc-singularity: adding detected 'latest' among 2 records: mriqc-0.15.0_1.1.0 from 2019-04-30T08:10:39.705Z
456/2910 guerriep/HPC: adding detected 'latest' among 1 records: tensorflow-latest-gpu-py3 from 2019-04-29T20:57:19.707Z
457/2910 IARCbioinfo/polysolver-singularity: adding detected 'latest' among 1 records: v4 from 2021-04-14T22:24:06.577Z
458/2910 jkadowaki/singularity_recipes: adding detected 'latest' among 1 records: pytorch_skimage from 2019-12-05T11:10:42.105Z
459/2910 BensonYang1999/hpl-cuda-singularity: adding detected 'latest' among 6 records: v6 from 2019-05-07T14:45:54.193Z
460/2910 VowpalWabbit/vowpal_wabbit: adding detected 'latest' among 2 records: debian-unstable-amd64 from 2019-05-01T22:22:20.552Z
461/2910 jlboat/BioinfoContainers: adding detected 'latest' among 33 records: vcftools from 2021-04-19T05:43:25.916Z
462/2910 rogerjiang01/tensorflow-singularity: adding detected 'latest' among 2 records: v1 from 2020-07-04T00:53:58.959Z
463/2910 Pepitaw/singularity: adding detected 'latest' among 1 records: try from 2019-05-03T21:23:36.136Z
464/2910 ertheisen/wildcat_centos: adding detected 'latest' among 1 records: hg19v1.centos from 2020-04-30T23:17:55.950Z
465/2910 leobii/swiftsim_singularity: adding detected 'latest' among 4 records: v4 from 2019-05-05T11:54:59.821Z
466/2910 bioconvert/bioconvert: adding detected 'latest' among 1 records: 0_3_0 from 2021-04-07T19:51:39.162Z
467/2910 nckucch/singularity: adding detected 'latest' among 2 records: ubuntubase-10.0-u from 2019-05-05T08:37:08.399Z
468/2910 russelltankl/SingularityHub: adding detected 'latest' among 1 records: cudatorchgym from 2019-05-06T04:14:38.918Z
469/2910 chaeger/ray_singularity: adding detected 'latest' among 1 records: recipe from 2019-05-06T15:37:43.867Z
470/2910 bouthilx/hpop-hub: adding detected 'latest' among 9 records: 8b52153 from 2019-05-09T22:11:40.004Z
471/2910 klshrinidhi/carla: adding detected 'latest' among 1 records: 0_9_5 from 2019-05-08T15:10:10.733Z
472/2910 enlznep/singularity-recipes: adding detected 'latest' among 3 records: caffe-opa from 2019-05-07T14:45:54.344Z
473/2910 nknowlton/singularity: adding detected 'latest' among 1 records: leafcutter from 2019-05-08T15:10:10.780Z
474/2910 TomHarrop/biopython-index-test: adding detected 'latest' among 1 records: biopython_index_test from 2019-05-09T08:14:52.685Z
475/2910 yinglilu/deeplearning_gpu_singularity: adding detected 'latest' among 2 records: 1.0.0 from 2021-03-09T02:54:02.249Z
476/2910 netcatninja/cookbook: adding detected 'latest' among 7 records: u1604 from 2019-10-15T14:42:29.879Z
477/2910 AllenInstitute/EM_aligner_python: adding detected 'latest' among 1 records: petsc from 2019-05-10T10:48:47.606Z
478/2910 Hanyu-Li/singularity_recipes: adding detected 'latest' among 1 records: horovod3 from 2019-05-10T20:18:29.510Z
479/2910 willgpaik/ubuntu_aci: adding detected 'latest' among 3 records: 1604 from 2020-08-07T21:23:43.649Z
480/2910 danielabler/dockerfiles: adding detected 'latest' among 3 records: libadjoint-2017-2_ants from 2021-03-02T14:21:36.610Z
481/2910 sonnhammergroup/Domainoid: adding detected 'latest' among 1 records: def from 2021-02-05T15:08:52.597Z
482/2910 rkpandya/CERR: adding detected 'latest' among 2 records: txt from 2020-11-20T09:39:22.220Z
483/2910 colleeneb/test_singularity: adding detected 'latest' among 2 records: test from 2019-05-16T20:22:33.708Z
484/2910 joaocaldeira/singularity_imgs: adding detected 'latest' among 7 records: py3_tf115 from 2020-05-25T21:33:24.101Z
485/2910 HenryDayHall/HiggsPhenoSingularity: adding detected 'latest' among 1 records: higgspheno from 2019-05-23T03:52:52.876Z
486/2910 vangalamaheshh/singularity: adding detected 'latest' among 1 records: test from 2019-05-15T18:46:10.369Z
487/2910 radoye/docks: adding detected 'latest' among 1 records: base from 2019-05-16T02:35:09.602Z
488/2910 wezen/singularity: adding detected 'latest' among 1 records: v1 from 2019-05-16T20:22:33.749Z
489/2910 baxpr/fmriqa: adding detected 'latest' among 1 records: v4.2.0 from 2019-05-17T08:23:25.035Z
490/2910 pndni/freesurfer-5.3.0-container: adding detected 'latest' among 1 records: 1.0.0 from 2019-05-17T20:05:29.600Z
491/2910 iem71/singularityRecipe: adding detected 'latest' among 4 records: zwei from 2019-05-21T15:12:30.946Z
492/2910 rgrandin/Singularity-QGIS: adding detected 'latest' among 3 records: fedora32 from 2021-02-06T18:21:26.707Z
493/2910 ohsu-cedar-comp-hub/Bulk-RNA-seq-pipeline-SE: adding detected 'latest' among 7 records: trim from 2019-06-10T23:33:39.528Z
494/2910 flome/keras: adding detected 'latest' among 1 records: py37-tensorflow from 2019-05-21T02:41:10.754Z
495/2910 DeepLearnPhysics/larcv3-singularity: adding detected 'latest' among 9 records: centos7-cuda-torch-larcv from 2020-05-08T10:38:11.273Z
496/2910 pauldhein/hpc-containers: adding detected 'latest' among 1 records: delphi from 2019-06-06T15:55:37.587Z
497/2910 edwardchalstrey1/turingbench: adding detected 'latest' among 4 records: mandelbrot_gpu from 2020-09-22T14:36:26.700Z
498/2910 kb31415926/singularity-test: adding detected 'latest' among 1 records: test from 2019-05-23T03:52:52.934Z
499/2910 bsiranosian/bin_genomes: adding detected 'latest' among 2 records: checkm from 2021-04-14T23:42:59.510Z
500/2910 sanchezivan/singularity_image_recipes: adding detected 'latest' among 7 records: container4 from 2019-07-30T16:20:08.326Z
501/2910 alan0415/Singularity-build: adding detected 'latest' among 1 records: v1 from 2019-05-26T05:45:57.619Z
502/2910 klabhub/singularity: adding detected 'latest' among 4 records: rclone from 2020-12-22T06:06:21.091Z
503/2910 klementc/singularityRecipes: adding detected 'latest' among 3 records: corda from 2019-08-14T14:19:50.422Z
504/2910 arcsUVA/deepcell-tf: adding detected 'latest' among 1 records: 0.1 from 2019-05-29T07:57:59.258Z
505/2910 bcaffo/kerasSingularity: adding detected 'latest' among 3 records: addrstudio from 2019-06-05T15:20:41.291Z
506/2910 bsiranosian/bens_1337_workflows: adding detected 'latest' among 11 records: align from 2021-04-14T03:38:43.881Z
507/2910 Poulami-Sarkar/Bengali-Hindi-OCR: adding detected 'latest' among 2 records: benocr from 2019-08-23T03:41:37.417Z
508/2910 mticlla/MetagenomicSnake: adding detected 'latest' among 2 records: preqc_v0_1 from 2021-02-03T10:46:21.130Z
509/2910 ambenj/bin_das_tool: adding detected 'latest' among 2 records: dastool from 2019-09-03T13:58:28.495Z
510/2910 Eric716/ericflow-bazel: adding detected 'latest' among 9 records: cuda10-tf1.13.1-py3.7 from 2019-11-01T09:55:46.248Z
511/2910 Eric716/tensorflow-gpu-cuda9.0: adding detected 'latest' among 1 records: fullversion from 2019-06-02T08:13:57.355Z
512/2910 justinblaber/b0_atlas_coreg_app: adding detected 'latest' among 1 records: 1.0.0 from 2019-10-09T15:47:27.925Z
513/2910 by256/periodic: adding detected 'latest' among 1 records: simg from 2019-06-05T15:20:41.410Z
514/2910 barbagroup/PetIBM: adding detected 'latest' among 3 records: 0.4.2-gpu-openmpi-xenial from 2019-08-13T20:21:27.155Z
515/2910 Delaunay/training-container: adding detected 'latest' among 1 records: rocm from 2019-06-06T16:11:53.886Z
516/2910 bmacherone/singularity: adding detected 'latest' among 2 records: scijupyter from 2019-06-08T01:44:30.058Z
517/2910 frankwillmore/singularity_image_recipes: adding detected 'latest' among 5 records: mcnda040614_gcc7_py36 from 2019-06-07T11:19:42.524Z
518/2910 frankwillmore/singularity_junk: adding detected 'latest' among 2 records: hello_mpi_pi from 2019-06-08T01:44:30.138Z
519/2910 darachm/freebarcodes: adding detected 'latest' among 1 records: v0.0.1 from 2019-06-07T11:19:42.467Z
520/2910 pbranson/simages: adding detected 'latest' among 1 records: pangeo-notebook from 2019-06-07T11:19:41.494Z
521/2910 joey3639570/singularity_tensorflow: adding detected 'latest' among 3 records: cuda9.0-tf1.13-ofed4.4 from 2019-09-10T00:12:54.681Z
522/2910 baxpr/connprep: adding detected 'latest' among 2 records: v2.1.0 from 2021-02-10T18:21:01.378Z
523/2910 qlan3/singularity-deffile: adding detected 'latest' among 2 records: explorer from 2019-08-04T16:49:57.177Z
524/2910 SKA-INAF/yandasoft-container: adding detected 'latest' among 1 records: bionic from 2019-09-06T07:27:51.256Z
525/2910 jpetucci/tensorflow_icsaci: adding detected 'latest' among 4 records: gpu-py3 from 2019-09-10T13:37:02.132Z
526/2910 ethancaballero/singularity-containers: adding detected 'latest' among 3 records: myia_benchmarks_prof_tvm from 2019-06-18T02:03:56.918Z
527/2910 Grelot/bioinfo_singularity_recipes: adding detected 'latest' among 4 records: obitoolsmbb from 2020-12-02T00:17:59.075Z
528/2910 mesnardo/petibm-rollingpitching: adding detected 'latest' among 3 records: petibm0.5.1-xenial from 2020-02-11T21:16:54.275Z
529/2910 fredjaya/rec-bench: adding detected 'latest' among 4 records: hyphy from 2019-06-27T08:32:44.511Z
530/2910 llucifer97/openposeaci: adding detected 'latest' among 1 records: rec from 2019-06-16T11:06:35.442Z
531/2910 mesnardo/petibm-decoupledibpm: adding detected 'latest' among 3 records: petibm0.5.1-xenial from 2020-02-11T17:37:58.223Z
532/2910 bstriner/tensorflow-cuda-10.1-cudnn7-devel-ubuntu16.04: adding detected 'latest' among 3 records: tf-nightly from 2021-03-31T13:34:25.045Z
533/2910 bstriner/tensorflow-cuda-10.0-cudnn7-devel-ubuntu16.04: adding detected 'latest' among 2 records: tf-nightly from 2020-07-04T01:27:08.361Z
534/2910 karltayeb/gp_fine_mapping: adding detected 'latest' among 2 records: gpu from 2019-06-24T14:48:05.229Z
535/2910 shengqh/bioinfo: adding detected 'latest' among 1 records: r_python2 from 2019-06-18T22:10:58.884Z
536/2910 granek/singularity-rstudio: adding detected 'latest' among 1 records: 3.6.0 from 2020-10-02T20:26:57.212Z
537/2910 rbrewster727/brewster_pipelines: adding detected 'latest' among 1 records: sgv_finder from 2019-06-24T14:48:03.806Z
538/2910 granek/singularity-rstudio-base: adding detected 'latest' among 1 records: 3.6.0 from 2021-01-23T10:08:41.234Z
539/2910 ertheisen/ferncanyon_centos: adding detected 'latest' among 1 records: mm10v1.centos from 2019-06-22T01:06:31.330Z
540/2910 spono/gears-singularity: adding detected 'latest' among 2 records: gears-cloudcompare from 2019-06-23T23:32:49.234Z
541/2910 bud42/ASHS: adding detected 'latest' among 1 records: v2.1.0 from 2019-06-25T05:49:24.165Z
542/2910 fmporter/GPUs: adding detected 'latest' among 1 records: cuda10 from 2020-08-17T14:28:58.053Z
543/2910 mvsurfsara/containers: adding detected 'latest' among 1 records: mpich.osu-apps from 2019-07-02T23:19:20.632Z
544/2910 rogerjiang01/Intel_parallel_studio-singularity: adding detected 'latest' among 1 records: intel-mpi from 2019-06-26T22:56:27.268Z
545/2910 DrVale83/bioinfo: adding detected 'latest' among 5 records: orthofinder from 2021-03-19T20:23:12.178Z
546/2910 jiayiliujiayi/R3.6sig: adding detected 'latest' among 2 records: r from 2019-07-02T23:19:22.495Z
547/2910 miguelcarcamov/container_docker: adding detected 'latest' among 6 records: casacore.gpuvmem.9.2.ubuntu1604 from 2021-03-11T12:31:38.571Z
548/2910 akojamil/nexo-chroma-container: adding detected 'latest' among 3 records: chroma from 2020-11-03T02:48:20.641Z
549/2910 darachm/singularity_python3_for_darach: adding detected 'latest' among 2 records: v0.0.4 from 2020-09-25T06:39:05.710Z
550/2910 msk-cer/CER_scripts: adding detected 'latest' among 2 records: homer from 2019-11-05T23:27:14.395Z
551/2910 bsmind/ChimbukoHubs: adding detected 'latest' among 5 records: centos from 2019-07-30T22:38:02.939Z
552/2910 TomHarrop/5acc: adding detected 'latest' among 1 records: five-accessions from 2019-07-29T03:37:13.925Z
553/2910 Grelot/seaConnect--dDocent: adding detected 'latest' among 1 records: seaconnect from 2021-03-01T21:44:35.318Z
554/2910 Grelot/clean-fastq: adding detected 'latest' among 1 records: cleanfastq from 2021-02-23T14:19:01.048Z
555/2910 TomHarrop/funannotate-singularity: adding detected 'latest' among 9 records: repeatmasker_4.0.9p2 from 2021-01-18T00:25:23.383Z
556/2910 emrebesogul/SNV-Calling-Test: adding detected 'latest' among 1 records: recipe from 2019-08-01T12:20:24.936Z
557/2910 rsettlage/singularity-rstudio: adding detected 'latest' among 1 records: 3.4.4 from 2019-08-02T11:09:21.730Z
558/2910 rickstaa/panda_autograsp: adding detected 'latest' among 3 records: ros_melodic-cuda10-bionic from 2020-03-30T11:40:06.598Z
559/2910 frankwillmore/singo: adding detected 'latest' among 1 records: hello_mpi_pi from 2019-08-02T22:31:03.451Z
560/2910 frankwillmore/singa: adding detected 'latest' among 2 records: hello_mofo from 2019-08-02T21:41:11.076Z
561/2910 colinmcnally/chains: adding detected 'latest' among 6 records: campaign008 from 2019-11-16T17:22:04.768Z
562/2910 timkphd/stuff: adding detected 'latest' among 4 records: 05221357 from 2020-08-13T17:28:44.637Z
563/2910 sdruskat/getpapers-singularity: adding detected 'latest' among 2 records: 0.2.2 from 2019-08-12T12:07:35.139Z
564/2910 AASHISHAG1/test: adding detected 'latest' among 2 records: kaldi from 2021-04-07T17:29:20.584Z
565/2910 RationalTangle/hcc: adding detected 'latest' among 3 records: py3-matt from 2021-02-02T05:21:09.804Z
566/2910 h3abionet/h3avarcall: adding detected 'latest' among 4 records: gatk from 2021-01-18T11:11:56.394Z
567/2910 drewpolasky/aci_puremd: adding detected 'latest' among 1 records: rec from 2019-08-12T14:28:23.574Z
568/2910 MuhsinFatih/singularityimages: adding detected 'latest' among 1 records: tensorflow_venv from 2020-03-15T13:21:22.047Z
569/2910 Katerintse/singularity_hub_test: adding detected 'latest' among 2 records: lscsoft from 2019-09-13T10:53:59.491Z
570/2910 piyu2181/singulariyu: adding detected 'latest' among 1 records: def from 2019-08-13T22:48:29.725Z
571/2910 piyu2181/singularity: adding detected 'latest' among 1 records: def from 2019-08-13T23:09:35.257Z
572/2910 Somayeh111/tensorflow_container: adding detected 'latest' among 1 records: tf_1.14 from 2019-08-14T22:10:03.043Z
573/2910 drewpolasky/deeplabcut_aci: adding detected 'latest' among 1 records: gpu from 2020-02-27T08:42:23.434Z
574/2910 pvelesko/singularity_files: adding detected 'latest' among 1 records: intelpython3_beer from 2019-08-19T20:31:56.272Z
575/2910 qibinc/singularity: adding detected 'latest' among 1 records: wav2letter from 2020-01-17T09:35:35.714Z
576/2910 stephansmit/paraview_containers: adding detected 'latest' among 2 records: paraview from 2020-09-30T22:14:20.600Z
577/2910 dp2ski/vscode_aci: adding detected 'latest' among 1 records: rec from 2019-08-23T15:38:34.177Z
578/2910 LuisBonillaR/singularity: adding detected 'latest' among 4 records: py3_tfstable from 2021-01-15T19:57:38.306Z
579/2910 MicroSTM/singularity_containers: adding detected 'latest' among 3 records: py36_pybullet_pybox2d_pytorch from 2019-10-01T14:02:21.979Z
580/2910 Himscipy/singularity_image_recipes: adding detected 'latest' among 1 records: hello_world from 2019-08-28T16:26:45.703Z
581/2910 nschiraldi/singularity: adding detected 'latest' among 3 records: cernvmfs from 2020-10-05T00:40:44.206Z
582/2910 bstriner/kaldi-image: adding detected 'latest' among 2 records: cpu from 2019-11-14T13:57:41.613Z
583/2910 drewpolasky/tinker-hp_aci: adding detected 'latest' among 1 records: rec from 2019-09-03T13:14:29.216Z
584/2910 hbraunDSP/containers: adding detected 'latest' among 1 records: xenial from 2019-09-03T18:28:45.202Z
585/2910 TomHarrop/racon-chunks: adding detected 'latest' among 3 records: racon-chunks_0.0.6 from 2020-01-08T23:34:39.205Z
586/2910 bhaveshshrimali/singularitFEniCS: adding detected 'latest' among 1 records: recipe from 2021-04-19T21:24:42.066Z
587/2910 timkphd/Containers: adding detected 'latest' among 2 records: cuda10 from 2020-06-05T21:14:28.429Z
588/2910 Clinical-Genomics/MIP: adding detected 'latest' among 33 records: bwa-0.7.17 from 2021-01-22T13:53:58.662Z
589/2910 Grelot/global_fish_genetic_diversity: adding detected 'latest' among 1 records: global_fish_genetic_diversity from 2021-02-22T09:04:03.974Z
590/2910 bilgelm/containers: adding detected 'latest' among 5 records: petanalysis from 2020-12-21T18:00:08.424Z
591/2910 kasbohm/dash-server: adding detected 'latest' among 1 records: def from 2019-09-18T18:32:21.947Z
592/2910 deanpettinga/containers: adding detected 'latest' among 3 records: snakemake from 2019-09-24T13:50:15.837Z
593/2910 Grelot/reserveBenefit--snpsdata_analysis: adding detected 'latest' among 1 records: snpsdata_analysis from 2020-10-30T14:26:08.337Z
594/2910 shubavarshini/microbiome: adding detected 'latest' among 1 records: def from 2019-09-26T13:06:26.899Z
595/2910 BarquistLab/proQ_conventionalMouse_dataAnalysis: adding detected 'latest' among 2 records: def from 2019-09-27T13:25:14.161Z
596/2910 UCL-BLIC/singularity_recipes: adding detected 'latest' among 6 records: sex_classifier_v0.2 from 2020-10-23T22:33:03.794Z
597/2910 seb-mueller/singularity_dropSeqPipe: adding detected 'latest' among 1 records: v04 from 2020-07-14T14:35:13.542Z
598/2910 afonsoguerra/CargoShip: adding detected 'latest' among 19 records: pysradb from 2021-03-09T07:03:01.703Z
599/2910 cteerara/FEniCS_Singularity: adding detected 'latest' among 2 records: def from 2019-10-01T04:58:42.016Z
600/2910 cteerara/FenicsSing: adding detected 'latest' among 1 records: def from 2019-10-01T05:19:20.774Z
601/2910 phelelani/nf-rnaSeqCount: adding detected 'latest' among 7 records: star from 2021-03-03T17:57:49.082Z
602/2910 jpetucci/centos7_icsaci: adding detected 'latest' among 1 records: base from 2020-05-01T02:28:42.277Z
603/2910 recap/MicroInfrastructure: adding detected 'latest' among 1 records: srm2local from 2019-10-04T11:25:03.193Z
604/2910 mticlla/OmicSingularities: adding detected 'latest' among 2 records: meta16s from 2021-01-13T16:06:38.365Z
605/2910 J35P312/SVDB: adding detected 'latest' among 1 records: 2.2.0 from 2021-04-14T15:29:48.216Z
606/2910 xiyaojin/singularity: adding detected 'latest' among 9 records: tf2p4_addons from 2021-03-24T18:22:32.585Z
607/2910 J35P312/vcf2cytosure: adding detected 'latest' among 3 records: 0.5.1 from 2020-06-12T21:52:07.621Z
608/2910 dominik-handler/AP_singu2: adding detected 'latest' among 2 records: ap_master from 2021-03-18T14:53:10.831Z
609/2910 metaganal/singularity-rstudio: adding detected 'latest' among 1 records: 3.6.1 from 2020-06-02T01:44:41.776Z
610/2910 anushree85/singularity_container: adding detected 'latest' among 1 records: test from 2019-10-17T13:56:08.598Z
611/2910 metaganal/singularity-rstudio-base: adding detected 'latest' among 1 records: 3.6.1 from 2020-06-02T01:50:08.782Z
612/2910 codeaster/container: adding detected 'latest' among 3 records: common.default from 2021-04-01T06:33:38.022Z
613/2910 maxkno/hepmc-singularity: adding detected 'latest' among 1 records: hepmc from 2019-10-22T10:26:13.012Z
614/2910 yinglilu/pytorch_gpu_singularity: adding detected 'latest' among 2 records: 1.7.0 from 2021-04-17T22:06:34.219Z
615/2910 yinglilu/niftynet_gpu_singularity: adding detected 'latest' among 1 records: 0.6.0 from 2020-09-29T11:07:02.282Z
616/2910 kellyuw/SingularityRecipes: adding detected 'latest' among 6 records: oldconnectome from 2019-10-31T04:37:00.310Z
617/2910 WVUHPC/singularity-r: adding detected 'latest' among 2 records: 3.6.1_xenial from 2019-10-24T20:06:27.608Z
618/2910 barbagroup/petibm-recipes: adding detected 'latest' among 4 records: 0.5.2-gpu-openmpi-centos7 from 2020-09-10T13:12:22.352Z
619/2910 ternaustralia/coesra-singularity-canopy: adding detected 'latest' among 1 records: canopy from 2020-12-14T04:35:32.132Z
620/2910 ternaustralia/coesra-singularity-knime: adding detected 'latest' among 1 records: knime from 2020-12-14T04:26:28.009Z
621/2910 ternaustralia/coesra-singularity-macroecodesktop: adding detected 'latest' among 1 records: macroecodesktop from 2020-12-14T04:36:31.212Z
622/2910 ternaustralia/coesra-singularity-dropbox: adding detected 'latest' among 1 records: dropbox from 2019-10-28T05:57:14.912Z
623/2910 ternaustralia/coesra-singularity-jupyter: adding detected 'latest' among 1 records: jupyter from 2020-12-14T04:10:31.376Z
624/2910 ternaustralia/coesra-singularity-qgis: adding detected 'latest' among 1 records: qgis from 2019-10-29T04:12:04.374Z
625/2910 ternaustralia/coesra-singularity-rstudio: adding detected 'latest' among 1 records: rstudio from 2020-12-22T03:26:47.789Z
626/2910 ternaustralia/coesra-singularity-owncloud: adding detected 'latest' among 1 records: owncloud from 2020-12-14T04:32:42.254Z
627/2910 psumionka-task/Singularity_Ubuntu-16-04: adding detected 'latest' among 1 records: def from 2019-10-29T15:52:30.591Z
628/2910 psumionka-task/Singularity_Scientific-7.x: adding detected 'latest' among 1 records: def from 2019-10-29T15:52:07.636Z
629/2910 psumionka-task/Singularity_Debian-9: adding detected 'latest' among 1 records: def from 2019-10-29T15:51:46.142Z
630/2910 psumionka-task/Singularity_CentOS-7.x: adding detected 'latest' among 1 records: def from 2019-10-29T16:46:23.998Z
631/2910 TomHarrop/ont-containers: adding detected 'latest' among 30 records: porechop_0.2.4 from 2021-04-12T22:53:40.049Z
632/2910 psumionka-task/Singularity_Ubuntu-16-04_OpenFOAM-7: adding detected 'latest' among 1 records: def from 2019-10-30T07:58:07.147Z
633/2910 psumionka-task/Singularity_Debian-9.x_OpenMPI-3.0.0: adding detected 'latest' among 1 records: def from 2019-10-30T10:01:06.021Z
634/2910 psumionka-task/Singularity_Ubuntu-16.04_OpenMPI-3.0.0: adding detected 'latest' among 1 records: def from 2019-10-30T10:05:24.594Z
635/2910 darachm/singularity_bartender: adding detected 'latest' among 2 records: v0.0.2 from 2021-01-15T01:51:13.360Z
636/2910 ddbj/singularity_postgresql: adding detected 'latest' among 4 records: 12.0 from 2021-04-02T01:04:22.471Z
637/2910 mbhall88/eipp-2019-singularity: adding detected 'latest' among 4 records: flye from 2021-01-25T02:33:16.591Z
638/2910 jemunro/nf-spotyping: adding detected 'latest' among 1 records: v0.0.1 from 2019-11-07T04:14:15.278Z
639/2910 GilbertoAlvarez/eipp-2019-singularity: adding detected 'latest' among 2 records: nanopolish from 2019-11-07T14:59:10.703Z
640/2910 sformic/eipp-2019-singularity: adding detected 'latest' among 1 records: flye from 2019-11-07T12:32:45.885Z
641/2910 gcgbarbosa/mtl: adding detected 'latest' among 1 records: pat from 2019-11-07T19:40:25.849Z
642/2910 MuhsinFatih/singularity_with_sudo: adding detected 'latest' among 1 records: 0.0-gpu-py3 from 2019-11-07T18:54:01.302Z
643/2910 arcsUVA/cryoCARE: adding detected 'latest' among 1 records: 0.1.0 from 2019-11-19T21:46:17.239Z
644/2910 arcsUVA/R: adding detected 'latest' among 1 records: 3.6.0 from 2019-11-10T18:50:15.304Z
645/2910 arcsUVA/patric: adding detected 'latest' among 1 records: 1.026 from 2019-11-10T18:56:55.564Z
646/2910 adswa/test_simg: adding detected 'latest' among 1 records: 1 from 2019-11-11T11:10:05.827Z
647/2910 adswa/resources: adding detected 'latest' among 2 records: 2 from 2021-04-15T13:39:00.915Z
648/2910 TomHarrop/assembly-utils: adding detected 'latest' among 11 records: quast_5.0.2 from 2021-03-15T23:45:08.849Z
649/2910 MasterRedz/groplu: adding detected 'latest' among 3 records: ubuntu from 2019-11-19T07:52:49.123Z
650/2910 arcsUVA/sumo: adding detected 'latest' among 1 records: 1.3.1 from 2019-11-13T16:17:23.595Z
651/2910 Distue/singularity_recipies: adding detected 'latest' among 1 records: mfold-3.5 from 2019-11-14T15:51:05.715Z
652/2910 Distue/mfold-3.5_singularity: adding detected 'latest' among 1 records: mfold-3.5 from 2020-04-25T05:16:22.914Z
653/2910 powerPlant/mrbayes-srf: adding detected 'latest' among 2 records: 3.2.7a from 2020-09-03T11:47:18.671Z
654/2910 baxpr/dwi-reorder: adding detected 'latest' among 1 records: v1.0.0 from 2019-11-21T19:20:30.363Z
655/2910 TomHarrop/seq-utils: adding detected 'latest' among 7 records: bbmap_38.76 from 2021-03-15T23:21:08.601Z
656/2910 TomHarrop/variant-utils: adding detected 'latest' among 18 records: vcftools_0.1.16 from 2021-03-04T00:21:39.054Z
657/2910 TomHarrop/align-utils: adding detected 'latest' among 12 records: samtools_1.10 from 2021-03-15T10:24:34.153Z
658/2910 TomHarrop/assemblers: adding detected 'latest' among 13 records: flye_2.8 from 2021-03-15T01:28:36.982Z
659/2910 baxpr/naleg-roi: adding detected 'latest' among 1 records: v1.0.0 from 2020-04-02T21:12:33.712Z
660/2910 TomHarrop/honeybee-genotype-pipeline: adding detected 'latest' among 12 records: honeybee_genotype_pipeline_v0.0.12 from 2021-01-27T23:38:53.224Z
661/2910 PhMueller/test_receipe: adding detected 'latest' among 2 records: xgboostonmnist from 2019-11-26T14:46:31.866Z
662/2910 MBlaschek/singularity-jupyter: adding detected 'latest' among 9 records: stuff from 2021-02-22T22:47:59.146Z
663/2910 TomHarrop/r-containers: adding detected 'latest' among 10 records: bioconductor_3.11 from 2021-04-13T02:15:38.947Z
664/2910 fshaikh4/Singularity: adding detected 'latest' among 4 records: fastsurfer from 2020-07-29T15:14:07.213Z
665/2910 tikk3r/lofar-grid-hpccloud: adding detected 'latest' among 8 records: lofar_sksp from 2021-04-08T10:20:47.824Z
666/2910 asarmakeeva/computational-case: adding detected 'latest' among 1 records: xenial from 2019-12-12T16:45:18.115Z
667/2910 darachm/singularity_bioinf_munger: adding detected 'latest' among 1 records: v0.0.1 from 2019-12-27T14:33:56.480Z
668/2910 1001-1100/csc771m-singularity: adding detected 'latest' among 1 records: recipe from 2019-12-14T19:49:56.596Z
669/2910 1001-1100/bioinfo: adding detected 'latest' among 1 records: recipe from 2019-12-14T11:14:43.489Z
670/2910 sjw42/icsheudiconv: adding detected 'latest' among 1 records: rec from 2019-12-16T18:50:16.959Z
671/2910 baxpr/bedpost-singularity: adding detected 'latest' among 3 records: v2.0.1 from 2020-02-19T16:30:09.686Z
672/2910 ertheisen/hohriver: adding detected 'latest' among 1 records: centos from 2019-12-19T20:30:45.778Z
673/2910 sschmeier/container-crisprseek: adding detected 'latest' among 1 records: 0.0.2 from 2020-04-21T20:57:56.226Z
674/2910 myzkyuki/singularity_recipe: adding detected 'latest' among 7 records: tf-2.3.1-gpu from 2020-12-02T09:27:14.497Z
675/2910 TomHarrop/misc-utils: adding detected 'latest' among 2 records: borgbackup_1.1.13 from 2020-09-15T05:11:12.991Z
676/2910 J35P312/Bianca_Singularity: adding detected 'latest' among 3 records: 0.0.2 from 2021-03-29T11:04:12.003Z
677/2910 tragu/singularity_test_mpi: adding detected 'latest' among 1 records: mpich from 2020-01-11T12:56:55.331Z
678/2910 wsjeon/marl-dev-setting: adding detected 'latest' among 1 records: zsh from 2020-01-17T22:11:20.097Z
679/2910 phelelani/nf-rnaSeqMetagen: adding detected 'latest' among 5 records: upset from 2021-04-12T17:00:29.600Z
680/2910 PhMueller/TestRepo: adding detected 'latest' among 1 records: xgboostonmnist from 2020-01-17T16:18:27.687Z
681/2910 darachm/singularity_jupyter: adding detected 'latest' among 2 records: v2.0.0 from 2021-03-10T23:46:29.494Z
682/2910 baxpr/dwipre-PNC: adding detected 'latest' among 1 records: v1.1.0 from 2020-01-28T16:18:25.894Z
683/2910 TomHarrop/py-containers: adding detected 'latest' among 3 records: biopython_1.73 from 2020-12-17T21:23:59.628Z
684/2910 SouthGreenPlatform/singularityRecipeFiles: adding detected 'latest' among 1 records: 7.12.def from 2021-04-04T09:13:23.440Z
685/2910 sschmeier/metafunc-container: adding detected 'latest' among 5 records: 0.0.4 from 2020-08-31T20:54:29.317Z
686/2910 coreyjadams/uboone_singularity: adding detected 'latest' among 2 records: slf7-balsam from 2020-01-31T20:17:44.629Z
687/2910 fcatus/hcc: adding detected 'latest' among 1 records: py3-pytorch from 2020-01-31T22:50:15.803Z
688/2910 peterk87/nf-villumina: adding detected 'latest' among 1 records: 2.0.0 from 2021-04-14T20:33:19.955Z
689/2910 TomHarrop/trinotate_pipeline: adding detected 'latest' among 1 records: v0.0.12 from 2020-12-02T02:08:22.702Z
690/2910 mcduta/singularity-hpc-mpi-benchmarks: adding detected 'latest' among 1 records: hpc-mpi-benchmarks__centos-8__openmpi-3.1.4 from 2020-06-21T12:50:04.469Z
691/2910 rnpratoori/damask_singularity: adding detected 'latest' among 5 records: def from 2020-03-28T21:13:15.159Z
692/2910 darachm/singularity_r_for_darach: adding detected 'latest' among 1 records: v0.0.15 from 2021-01-15T07:27:35.549Z
693/2910 vibaotram/singularity-container: adding detected 'latest' among 12 records: guppy4.0.14gpu-conda-api from 2021-04-01T10:59:47.265Z
694/2910 darachm/singularity_ubuntu: adding detected 'latest' among 1 records: v1.0.0 from 2020-09-24T09:59:48.149Z
695/2910 motroy/singularity-qiime2: adding detected 'latest' among 3 records: 2019.10.perc_norm_comp from 2020-07-02T10:58:48.713Z
696/2910 descostesn/singularities: adding detected 'latest' among 13 records: gemv330 from 2021-01-22T15:37:55.573Z
697/2910 amenra99/hpc-ml: adding detected 'latest' among 1 records: centos7-python37 from 2020-06-29T08:56:03.268Z
698/2910 AstronomerJoe/GPUs2: adding detected 'latest' among 1 records: cuda10 from 2020-03-23T15:56:45.532Z
699/2910 fmporter/Joe: adding detected 'latest' among 1 records: cuda10 from 2020-03-23T16:34:22.001Z
700/2910 sjw42/fmriprep_icsaci: adding detected 'latest' among 1 records: rec from 2020-10-06T13:51:31.001Z
701/2910 hexmek/container: adding detected 'latest' among 59 records: metawap_docker from 2021-04-15T08:45:34.895Z
702/2910 lluciesmith/singularity_imgs: adding detected 'latest' among 3 records: py3_tf23 from 2021-02-22T13:56:10.580Z
703/2910 baxpr/sct-singularity: adding detected 'latest' among 3 records: v3.3.1 from 2020-08-13T21:08:59.313Z
704/2910 FlorianCHA/singularity_containers: adding detected 'latest' among 7 records: rmarkdown from 2021-03-31T13:51:11.068Z
705/2910 sschmeier/container-kraken2: adding detected 'latest' among 1 records: 202002 from 2020-12-10T09:33:59.425Z
706/2910 ctmrbio/stag-mwc: adding detected 'latest' among 8 records: stag-mwc from 2021-04-19T04:48:22.722Z
707/2910 baxpr/dwipre-PNC-edit: adding detected 'latest' among 1 records: v1.0.0 from 2020-03-05T13:37:13.669Z
708/2910 fenz/mlperf-inference: adding detected 'latest' among 1 records: imageclass-gpu-v0.5 from 2020-02-29T18:21:00.978Z
709/2910 Grelot/smk_stacks_workflow: adding detected 'latest' among 1 records: gbs_workflow from 2020-03-13T10:51:42.156Z
710/2910 vibaotram/baseDmux: adding detected 'latest' among 1 records: deepbinner-api from 2020-03-04T10:02:20.035Z
711/2910 adityabalu/pytorch_gpu_singularity: adding detected 'latest' among 1 records: 1.4.0 from 2020-05-28T01:22:31.652Z
712/2910 bahlolab/nf-tbtyper: adding detected 'latest' among 2 records: tbtyper_v0.0 from 2020-04-11T02:07:57.963Z
713/2910 motroy/singularity-mob-suite: adding detected 'latest' among 2 records: v3.0.0 from 2021-01-13T18:30:35.852Z
714/2910 BioRRW/Reads2Resistome: adding detected 'latest' among 1 records: 0.1 from 2021-01-08T19:52:19.144Z
715/2910 datalad/datalad-extensions: adding detected 'latest' among 1 records: buildenv-git-annex-buster from 2021-04-19T02:47:12.999Z
716/2910 amit112amit/ubuntu_numba: adding detected 'latest' among 1 records: v0 from 2020-03-24T10:04:15.220Z
717/2910 AstronomerJoe/GPUs3: adding detected 'latest' among 1 records: cuda10 from 2020-03-25T02:20:37.595Z
718/2910 moritzschaefer/diffTF: adding detected 'latest' among 1 records: python from 2020-03-26T17:30:48.634Z
719/2910 jsmentch/analyze-fmri: adding detected 'latest' among 15 records: nat_img_gpu from 2021-04-16T23:06:34.172Z
720/2910 AndresTanasijczuk/singularity-lscsoft: adding detected 'latest' among 1 records: centos7 from 2020-09-25T10:21:10.552Z
721/2910 masoudrezaie/Singularity: adding detected 'latest' among 2 records: 2 from 2020-08-17T11:27:33.630Z
722/2910 masoudrezai/Singularity: adding detected 'latest' among 10 records: 13 from 2021-03-10T08:42:57.088Z
723/2910 bahlolab/nf-mix-infect: adding detected 'latest' among 2 records: rocker_verse_bioc from 2020-04-07T06:50:03.543Z
724/2910 bahlolab/nf-quanttb: adding detected 'latest' among 1 records: nf_quanttb_v0.1 from 2020-04-08T05:12:16.389Z
725/2910 ulorentz/singularity_imgs: adding detected 'latest' among 5 records: py3_tf114 from 2020-04-10T17:37:55.832Z
726/2910 alibaba4055/dockerfiles: adding detected 'latest' among 1 records: gpu from 2020-04-15T12:51:07.186Z
727/2910 IARCbioinfo/RNAseq-nf: adding detected 'latest' among 3 records: v2.4 from 2021-02-10T15:35:45.538Z
728/2910 IARCbioinfo/abra-nf: adding detected 'latest' among 1 records: v3.0 from 2020-07-13T14:50:58.413Z
729/2910 IARCbioinfo/BQSR-nf: adding detected 'latest' among 1 records: v1.1 from 2020-07-13T15:03:36.523Z
730/2910 h3abionet/h3ameta: adding detected 'latest' among 11 records: metaphlan2 from 2020-05-15T06:00:41.790Z
731/2910 peterk87/nf-virontus: adding detected 'latest' among 2 records: 1.1.0 from 2021-03-31T21:11:37.197Z
732/2910 PimPaardekooper2/singularity_containers: adding detected 'latest' among 3 records: gridftp from 2020-05-16T11:52:53.477Z
733/2910 sohojai/singularity_mpi_test_recipe: adding detected 'latest' among 1 records: openmpi from 2020-05-06T09:04:34.092Z
734/2910 kangzhiq/GSoC2020: adding detected 'latest' among 2 records: lip2wav_new from 2021-04-01T17:33:01.518Z
735/2910 alex-chunhui-yang/containers: adding detected 'latest' among 1 records: pytorch from 2020-05-11T03:16:31.539Z
736/2910 Himani2000/GSOC_2020: adding detected 'latest' among 1 records: clustering from 2020-08-23T12:36:24.584Z
737/2910 kangzhiq/test_singularity_2: adding detected 'latest' among 1 records: test from 2020-05-12T22:38:36.429Z
738/2910 nalcala/mutect-nf: adding detected 'latest' among 3 records: v2.1_gatk2 from 2020-05-20T14:16:15.007Z
739/2910 cpllab/lm-zoo: adding detected 'latest' among 1 records: grnn from 2020-05-15T23:03:53.166Z
740/2910 nhartwic/salk-containers: adding detected 'latest' among 4 records: fun from 2020-11-11T22:42:55.400Z
741/2910 DylanYang7225/singularity_ML: adding detected 'latest' among 1 records: rcp from 2020-05-17T16:23:45.862Z
742/2910 DylanYang7225/singularity_connectome: adding detected 'latest' among 1 records: rcp from 2020-05-17T17:03:54.411Z
743/2910 motroy/singularity-chewie: adding detected 'latest' among 4 records: v2.6.0 from 2021-02-17T21:23:03.783Z
744/2910 IARCbioinfo/mutect-nf: adding detected 'latest' among 6 records: v2.2 from 2020-07-20T06:24:00.597Z
745/2910 IARCbioinfo/vcf_normalization-nf: adding detected 'latest' among 1 records: v1.1 from 2021-02-15T13:45:08.316Z
746/2910 IARCbioinfo/table_annovar-nf: adding detected 'latest' among 1 records: v1.1 from 2021-02-15T16:05:01.670Z
747/2910 dmadisetti/pd3: adding detected 'latest' among 1 records: nightly from 2020-12-08T15:25:09.408Z
748/2910 Xentrics/jupyter-r-base: adding detected 'latest' among 8 records: geo2rnaseq from 2021-02-17T17:51:14.540Z
749/2910 jasteen/singularity: adding detected 'latest' among 4 records: hiplex_v3 from 2020-06-09T22:49:48.656Z
750/2910 frankier/singularity_containers: adding detected 'latest' among 1 records: openpose-multi from 2020-06-01T13:26:51.397Z
751/2910 Xiaoyu-Lu/GSoC_2020: adding detected 'latest' among 1 records: trial from 2020-08-13T02:15:29.145Z
752/2910 iferres/ncov2019-artic-nf: adding detected 'latest' among 2 records: qc from 2021-03-30T11:01:38.591Z
753/2910 votti/singularity-builds: adding detected 'latest' among 1 records: miniconda3mamba from 2020-06-05T18:58:20.441Z
754/2910 Zhangzhehao1995/MyContainer: adding detected 'latest' among 1 records: tf1 from 2020-06-06T00:31:12.383Z
755/2910 jafaruddinlie/shub: adding detected 'latest' among 2 records: vardict_1 from 2020-08-29T02:16:03.673Z
756/2910 baxpr/thaltrack-whole: adding detected 'latest' among 2 records: v3.0.3 from 2020-07-07T15:07:44.125Z
757/2910 shawnrosofsky/Singularity-Recipies: adding detected 'latest' among 1 records: simflowny_theta from 2020-06-17T21:10:43.276Z
758/2910 HanLabUNLV/hanlab_singularity_defs: adding detected 'latest' among 4 records: r.3.6.3.bioc from 2020-06-11T03:36:41.577Z
759/2910 peterk87/nf-illmap: adding detected 'latest' among 1 records: 1.0.0 from 2021-04-15T05:22:50.005Z
760/2910 Yuqing66/Singularity: adding detected 'latest' among 2 records: pypackage from 2020-10-31T00:31:21.454Z
761/2910 clulab/hpc-ml: adding detected 'latest' among 6 records: centos7-python3.7-transformers4.1.1 from 2021-03-03T20:38:57.445Z
762/2910 SouthGreenPlatform/CulebrONT_pipeline: adding detected 'latest' among 8 records: shasta-0.7.0.def from 2021-02-12T09:56:17.428Z
763/2910 rickstaa/deep_robotics_singularity_recipes: adding detected 'latest' among 1 records: tf_gpu-conda3-libfreenect2-ros_kinetic-libfranka-moveit-cuda10-xenial from 2020-09-29T13:59:20.695Z
764/2910 I-Hao/singularity: adding detected 'latest' among 2 records: shannon from 2020-06-19T20:44:24.398Z
765/2910 motroy/singularity-pyseer: adding detected 'latest' among 3 records: v1.3.6.panaroo.unitigs from 2020-08-13T21:01:33.586Z
766/2910 guy1ziv2/bestmap: adding detected 'latest' among 1 records: def from 2021-01-20T14:27:16.143Z
767/2910 pgpmartin/SingIMG: adding detected 'latest' among 3 records: r36_nanobac from 2020-10-29T19:37:54.994Z
768/2910 sodalite-hpe/modak-containers: adding detected 'latest' among 5 records: ubuntu-base from 2020-06-29T12:37:26.452Z
769/2910 daviesdrew/variantcalling: adding detected 'latest' among 2 records: 0.0 from 2020-08-21T20:22:32.921Z
770/2910 bhaveshshrimali/singularitydealii: adding detected 'latest' among 1 records: recipe from 2020-06-28T00:59:24.545Z
771/2910 ddbj/singularity_mysql: adding detected 'latest' among 1 records: 5.6 from 2021-03-05T11:10:22.923Z
772/2910 Grayson3455/My-tigar: adding detected 'latest' among 1 records: def from 2020-12-18T21:56:27.396Z
773/2910 sodalite-hpe/modak: adding detected 'latest' among 11 records: cp2k-mpich from 2020-12-06T04:30:45.536Z
774/2910 sunyi000/covid-annotation: adding detected 'latest' among 1 records: covid from 2020-07-01T20:45:30.701Z
775/2910 prete/singularity-recipes: adding detected 'latest' among 2 records: 4.0.2 from 2020-08-13T20:31:55.962Z
776/2910 bast/openmpi: adding detected 'latest' among 1 records: 4.0.4-gcc-9.3.0 from 2021-02-01T15:32:49.604Z
777/2910 frankier/gsoc2020: adding detected 'latest' among 1 records: cineast from 2020-09-22T03:43:40.045Z
778/2910 leoisl/Singularity_recipes: adding detected 'latest' among 1 records: medaka from 2020-08-11T13:21:28.968Z
779/2910 IARCbioinfo/alignment-nf: adding detected 'latest' among 3 records: v1.2 from 2021-04-15T07:35:19.851Z
780/2910 darachm/singularity_qc: adding detected 'latest' among 1 records: v0.0.1 from 2021-01-05T06:13:40.693Z
781/2910 mglubber/krater: adding detected 'latest' among 3 records: variants from 2020-07-20T15:17:21.732Z
782/2910 IARCbioinfo/fastqc-nf: adding detected 'latest' among 1 records: v1.1 from 2021-04-19T21:08:51.773Z
783/2910 sskashaf/Containers: adding detected 'latest' among 13 records: metawrap from 2021-03-21T01:17:24.379Z
784/2910 dmjordan/gatk-docker: adding detected 'latest' among 7 records: mysql from 2020-07-29T00:09:17.427Z
785/2910 drewpolasky/dream3d_aci: adding detected 'latest' among 1 records: rec from 2020-07-22T14:12:12.700Z
786/2910 annacprice/containerCI-test: adding detected 'latest' among 23 records: abricate-latest from 2020-10-28T18:37:32.725Z
787/2910 baxpr/dwipre-NDWR: adding detected 'latest' among 2 records: v1.1.0 from 2020-07-31T00:04:32.905Z
788/2910 datalad-tester/dev-containers: adding detected 'latest' among 2 records: 16.04.20200722.1 from 2020-08-31T16:29:43.507Z
789/2910 cokelaer/damona: adding detected 'latest' among 4 records: r_4.0.2 from 2021-02-18T13:32:20.308Z
790/2910 sskashaf/MAG_wf_containers: adding detected 'latest' among 10 records: preprocessing from 2021-04-17T02:32:59.679Z
791/2910 IARCbioinfo/quantiseq-nf: adding detected 'latest' among 2 records: v1.1 from 2020-10-01T13:21:31.876Z
792/2910 cory-weller/singularity: adding detected 'latest' among 5 records: multiqc from 2021-03-29T21:04:12.819Z
793/2910 IARCbioinfo/nf_coverage_demo: adding detected 'latest' among 1 records: v2.3 from 2021-03-31T09:00:31.972Z
794/2910 dkafkes/singularity_imgs: adding detected 'latest' among 1 records: py3_pnnl from 2020-07-29T19:11:40.431Z
795/2910 skinmicrobiome/MAG_containers: adding detected 'latest' among 7 records: assembly from 2020-10-20T02:41:50.429Z
796/2910 baxpr/mniconn: adding detected 'latest' among 4 records: v3.1.2 from 2021-03-11T19:14:11.476Z
797/2910 sc-eQTLgen-consortium/WG1-pipeline-QC: adding detected 'latest' among 2 records: imputation from 2021-03-30T03:09:54.511Z
798/2910 TomHarrop/csdemux: adding detected 'latest' among 3 records: csdemux_v0.0.4 from 2020-12-10T20:46:14.476Z
799/2910 nesi/nesi-singularity-recipes: adding detected 'latest' among 1 records: turbo_xfce_centos from 2020-11-03T02:29:10.562Z
800/2910 uabrc/singularity-r: adding detected 'latest' among 1 records: 4.0.2 from 2020-10-20T19:31:00.447Z
801/2910 uabrc/singularity-rstudio: adding detected 'latest' among 1 records: 4.0.2 from 2020-10-20T19:44:54.728Z
802/2910 edg1983/GREEN-VARAN: adding detected 'latest' among 1 records: green-varan_v1 from 2021-03-23T13:05:51.073Z
803/2910 IARCbioinfo/NGSCheckMate-nf: adding detected 'latest' among 1 records: v1.1 from 2021-01-27T14:28:33.576Z
804/2910 Drew-Oli/Singularity_containers: adding detected 'latest' among 1 records: bioconductor_3.9 from 2020-08-10T02:08:53.473Z
805/2910 libii/ubuntu-python3-hello-world: adding detected 'latest' among 1 records: sif from 2020-08-07T05:53:59.815Z
806/2910 drewpolasky/r_aci: adding detected 'latest' among 1 records: rec from 2020-08-07T15:28:38.815Z
807/2910 d-w-moore/zipit: adding detected 'latest' among 1 records: alpine from 2020-08-19T20:16:31.944Z
808/2910 MatthiasEb/neurovista_evaluation: adding detected 'latest' among 1 records: nv_eval from 2020-10-06T11:25:21.052Z
809/2910 IARCbioinfo/strelka2-nf: adding detected 'latest' among 2 records: v1.2 from 2021-02-25T14:21:45.496Z
810/2910 uabrc/anaconda3: adding detected 'latest' among 1 records: 07 from 2020-08-18T14:57:44.451Z
811/2910 EliseJ/kay_singularity_images: adding detected 'latest' among 6 records: julia_deps from 2021-02-02T13:45:32.428Z
812/2910 sskashaf/Rcontainers: adding detected 'latest' among 1 records: biomart from 2020-08-18T20:35:38.923Z
813/2910 PPKoller/SHub: adding detected 'latest' among 4 records: root6.geant4.optsim.ubuntu-18.04 from 2021-02-06T11:49:54.946Z
814/2910 darachm/PyFitSeq: adding detected 'latest' among 1 records: v0.0.1-alpha from 2020-08-19T04:38:24.674Z
815/2910 semarpetrus/singularity_containers_private: adding detected 'latest' among 2 records: assembly from 2020-12-18T23:16:40.626Z
816/2910 hlya23dd/Code_evaluation_Container: adding detected 'latest' among 1 records: fea from 2020-08-24T12:09:56.458Z
817/2910 cory-weller/HS-reconstruction-gwas: adding detected 'latest' among 2 records: utils from 2020-09-17T13:44:05.220Z
818/2910 byrdsmyth/custom_highlights_baselines: adding detected 'latest' among 1 records: custom_baselines.def from 2020-08-28T01:27:35.657Z
819/2910 zhihongyou/Singularity-OpenFOAM: adding detected 'latest' among 1 records: def from 2020-08-28T18:50:29.768Z
820/2910 EdOates84/Show-Segmentation-2020: adding detected 'latest' among 1 records: trial from 2020-08-30T17:46:59.792Z
821/2910 EdOates84/show_segmentation_2020_singularity: adding detected 'latest' among 1 records: clustering from 2020-08-30T19:04:14.419Z
822/2910 hsonntag/singularity-containers: adding detected 'latest' among 1 records: python from 2020-09-18T08:01:46.050Z
823/2910 AquaL1te/singularity: adding detected 'latest' among 1 records: def from 2020-09-01T12:04:06.538Z
824/2910 IARCbioinfo/svaba-nf: adding detected 'latest' among 1 records: v1.0 from 2021-01-12T23:25:39.937Z
825/2910 cyang31/containers: adding detected 'latest' among 8 records: ubuntu_tf from 2021-04-04T22:43:36.033Z
826/2910 CallumWalley/RSE20_lolcow: adding detected 'latest' among 1 records: lolcow from 2020-09-11T03:56:23.822Z
827/2910 chrisvriend/ENIGMA_subthal: adding detected 'latest' among 4 records: s3stretch from 2021-04-15T10:17:49.548Z
828/2910 alex-chunhui-yang/container: adding detected 'latest' among 14 records: tf_einops from 2021-04-04T23:08:49.085Z
829/2910 mattocci27/dockerfiles: adding detected 'latest' among 1 records: def from 2020-09-11T10:40:08.921Z
830/2910 Tianhao1108/singularity: adding detected 'latest' among 1 records: recipe from 2020-09-14T23:51:39.187Z
831/2910 drneavin/SingularityBaseImages: adding detected 'latest' among 6 records: r363_python368 from 2021-03-24T03:53:41.404Z
832/2910 ous-uio-bioinfo-core/mirdeep_workflow: adding detected 'latest' among 2 records: mirdeep2 from 2020-11-04T14:21:52.183Z
833/2910 c3se/containers: adding detected 'latest' among 9 records: tensorflow-v2.3.1-tf2-py3-gpu-jupyter from 2021-04-15T09:02:40.203Z
834/2910 wilkinson-nu/nuisance_project: adding detected 'latest' among 1 records: 34.36_pythia6.def from 2020-09-17T15:35:11.447Z
835/2910 adswa/python-ml: adding detected 'latest' among 1 records: 1 from 2021-01-29T08:18:13.432Z
836/2910 Aucomte/Containers: adding detected 'latest' among 1 records: r.def from 2020-09-22T12:05:54.314Z
837/2910 chmendoza/max-sliced_covariance: adding detected 'latest' among 1 records: 20201022 from 2020-09-24T02:40:47.161Z
838/2910 sinaehsani6/hpc-singularity: adding detected 'latest' among 2 records: centos7-python3.7-transformers2.11.0-imagecrawl from 2020-12-06T22:04:24.092Z
839/2910 baxpr/cersuit: adding detected 'latest' among 2 records: v2.1.0 from 2020-10-05T20:06:38.873Z
840/2910 statiksof/singularity-recipes: adding detected 'latest' among 3 records: jupyterhub from 2020-11-19T14:21:34.836Z
841/2910 ous-uio-bioinfo-core/containerised_ATACseq_pipeline: adding detected 'latest' among 13 records: picard from 2021-03-06T01:07:24.232Z
842/2910 fzimmermann89/idi: adding detected 'latest' among 5 records: py38 from 2021-01-25T14:57:55.946Z
843/2910 nhartwic/salk_containers_two_electric_bugaloo: adding detected 'latest' among 1 records: assembly from 2020-10-03T02:33:28.032Z
844/2910 edg1983/Singularity_images: adding detected 'latest' among 6 records: vcf_processing.def from 2021-01-20T17:10:10.597Z
845/2910 shwertt/neurovista_evaluation_sw: adding detected 'latest' among 1 records: nv_eval from 2020-10-07T08:00:14.383Z
846/2910 shiningsurya/my-singularities: adding detected 'latest' among 3 records: psrppd from 2021-04-16T08:55:09.577Z
847/2910 HenryDayHall/madspin_singularity: adding detected 'latest' among 1 records: mg5_ma5_madspin from 2020-10-08T16:43:44.035Z
848/2910 ktmeaton/plague-phylogeography: adding detected 'latest' among 1 records: plot from 2020-10-09T14:29:38.073Z
849/2910 mattocci27/r-containers: adding detected 'latest' among 1 records: def from 2021-03-09T14:30:03.067Z
850/2910 powellgenomicslab/sceQTL_pipelines: adding detected 'latest' among 2 records: sceqtl_base from 2021-03-31T12:07:44.594Z
851/2910 yh549848/singularity-rstudio-rnaseqde: adding detected 'latest' among 1 records: 0.0.0.9000 from 2020-11-11T08:55:54.101Z
852/2910 yh549848/singularity-derfinder: adding detected 'latest' among 1 records: 1.22.0 from 2020-10-16T06:25:41.457Z
853/2910 yh549848/singularity-fastqc: adding detected 'latest' among 1 records: 0.11.9 from 2021-04-01T21:06:42.168Z
854/2910 yh549848/singularity-genomepy: adding detected 'latest' among 1 records: 0.8.1 from 2020-10-16T05:40:04.655Z
855/2910 yh549848/singularity-hisat2: adding detected 'latest' among 2 records: 2.2.1 from 2021-04-08T20:45:04.642Z
856/2910 yh549848/singularity-kallisto: adding detected 'latest' among 2 records: 0.46.1 from 2020-10-16T05:43:24.303Z
857/2910 yh549848/singularity-bowtie2: adding detected 'latest' among 1 records: 2.4.1 from 2020-10-16T12:05:38.593Z
858/2910 yh549848/singularity-igv: adding detected 'latest' among 1 records: 2.8.2 from 2020-10-16T12:09:26.038Z
859/2910 adigenova/nf-gene-fusions: adding detected 'latest' among 1 records: v1.0 from 2020-10-29T17:51:09.928Z
860/2910 yh549848/singularity-rsem: adding detected 'latest' among 1 records: 1.3.1 from 2020-10-17T15:29:53.332Z
861/2910 yh549848/singularity-samtools: adding detected 'latest' among 1 records: 1.9 from 2020-10-17T15:29:48.289Z
862/2910 yh549848/singularity-star: adding detected 'latest' among 1 records: 2.7.3a from 2020-10-17T15:30:22.625Z
863/2910 fenz-org/tensorflow: adding detected 'latest' among 6 records: 2.1.0-c_anaconda-python-3.7-gpu from 2020-10-31T14:48:26.206Z
864/2910 yh549848/singularity-stringtie: adding detected 'latest' among 3 records: 2.0.6 from 2020-10-18T17:45:49.315Z
865/2910 yh549848/singularity-tophat2: adding detected 'latest' among 1 records: 2.1.1 from 2020-10-18T16:41:21.431Z
866/2910 yh549848/singularity-trimmomatic: adding detected 'latest' among 1 records: 0.39 from 2020-10-18T16:42:46.484Z
867/2910 HERA-Team/hera-singularity: adding detected 'latest' among 3 records: hera1 from 2021-04-14T08:40:54.184Z
868/2910 pernillaericsson/shub_testing: adding detected 'latest' among 4 records: v0.7 from 2020-10-28T12:35:52.452Z
869/2910 provarepro/mlperf-inference: adding detected 'latest' among 7 records: v0.7-openvino-2020.3.1-python3.6-gcc-7.5.0 from 2021-04-13T08:01:21.407Z
870/2910 darachm/singularity_ncbi-blast: adding detected 'latest' among 1 records: v0.0.0 from 2020-10-29T21:33:06.479Z
871/2910 darachm/singularity_ncbi-entrez: adding detected 'latest' among 1 records: v0.0.0 from 2020-10-29T22:47:20.359Z
872/2910 MRChemSoft/mrchem-singularity: adding detected 'latest' among 4 records: v1.0.1-openmpi4.0.5 from 2021-04-16T13:08:13.309Z
873/2910 WhalleyT/singularity-recipes: adding detected 'latest' among 4 records: covid from 2021-04-14T21:56:11.348Z
874/2910 JossWhittle/Opt-ID-Env: adding detected 'latest' among 4 records: env-v3-cuda110 from 2020-12-14T16:59:53.897Z
875/2910 WhalleyT/covid-immune-selection: adding detected 'latest' among 1 records: immune_pressure from 2020-10-30T14:14:17.411Z
876/2910 fburic/candia: adding detected 'latest' among 1 records: def from 2021-04-16T13:16:50.424Z
877/2910 frankier/openpose_containers: adding detected 'latest' among 4 records: focal_multi from 2021-04-16T15:26:43.115Z
878/2910 rickstaa/deep-robotics-singularity-recipes: adding detected 'latest' among 5 records: tf_gpu-opencv2-conda3-ros_kinetic-libfranka-moveit-cuda10-xenial from 2020-11-04T20:23:52.311Z
879/2910 cblessing24/pytorch-singularity: adding detected 'latest' among 2 records: v3.8-torch1.7.0-dj0.12.7 from 2021-02-05T18:09:03.306Z
880/2910 piyanatk/singularity-containers: adding detected 'latest' among 1 records: one-point-stats from 2020-11-10T16:45:45.924Z
881/2910 sinzlab/pytorch-singularity: adding detected 'latest' among 2 records: v3.8-torch1.7.0-dj0.12.7 from 2021-04-19T21:16:53.275Z
882/2910 a-slide/singularity: adding detected 'latest' among 1 records: guppy_4.2.2 from 2020-11-13T10:27:34.171Z
883/2910 manuel-munoz-aguirre/singularity-pytorch-gpu: adding detected 'latest' among 1 records: 1.0.0 from 2021-04-14T00:15:43.406Z
884/2910 bbearce/singularity: adding detected 'latest' among 1 records: test from 2020-11-17T20:02:21.026Z
885/2910 ChunCun/container: adding detected 'latest' among 1 records: torch from 2020-11-18T06:07:14.361Z
886/2910 lukegun/BIOMEC: adding detected 'latest' among 1 records: def from 2020-11-19T06:30:00.293Z
887/2910 mAGLAVE/scRNAseq: adding detected 'latest' among 3 records: 1.0.1 from 2021-02-23T13:09:23.944Z
888/2910 SergFern/Variant_Calling: adding detected 'latest' among 2 records: def from 2021-01-20T16:56:55.067Z
889/2910 TomHarrop/phase-honeybee-vcf: adding detected 'latest' among 1 records: phase_honeybee_vcf_v0.0.2 from 2020-12-12T05:30:36.187Z
890/2910 mdzik/TCLB_singularity: adding detected 'latest' among 1 records: ubuntu2004_cuda11 from 2020-12-17T09:23:24.078Z
891/2910 AroArz/singularity_playground: adding detected 'latest' among 3 records: biobakery from 2021-04-19T12:57:53.480Z
892/2910 bwbellmath/pytorch_gpu_singularity: adding detected 'latest' among 1 records: 1.7.0 from 2020-12-07T20:57:53.214Z
893/2910 cblessing24/singularity-test: adding detected 'latest' among 2 records: v0.1 from 2020-12-08T16:13:54.749Z
894/2910 Gresliebear/Singularity_container_HPC_OP: adding detected 'latest' among 2 records: op_py2_image from 2021-03-29T23:03:55.580Z
895/2910 aaron-dees/singularityImages: adding detected 'latest' among 2 records: mpi_host_container_example from 2020-12-10T15:53:28.738Z
896/2910 AndresTanasijczuk/singularity-gfal2: adding detected 'latest' among 1 records: centos7 from 2020-12-14T09:42:42.589Z
897/2910 JossWhittle/Opt-ID: adding detected 'latest' among 1 records: env-v2 from 2021-03-04T09:32:51.451Z
898/2910 James-S-Santangelo/singularity-recipes: adding detected 'latest' among 5 records: angsd_v0.933 from 2021-04-01T14:27:49.517Z
899/2910 Gresliebear/test_example_singularity_hub: adding detected 'latest' among 1 records: tag_name from 2020-12-20T03:41:53.492Z
900/2910 TomHarrop/pollen-its-wrapper: adding detected 'latest' among 3 records: v0.0.3 from 2020-12-22T02:47:35.030Z
901/2910 mkandes/naked-singularity: adding detected 'latest' among 36 records: centos-7.9.2009 from 2021-04-17T19:57:15.579Z
902/2910 maxpkatz/singularity_image_files: adding detected 'latest' among 1 records: cosmic_tagging_tf_2010 from 2021-01-06T19:19:08.564Z
903/2910 darachm/containers: adding detected 'latest' among 3 records: r-plus from 2021-03-03T04:32:25.360Z
904/2910 draguar/vip_simulators: adding detected 'latest' among 1 records: 0.10.0 from 2021-01-05T09:42:14.470Z
905/2910 barbagroup/geoclaw-landspill: adding detected 'latest' among 4 records: v1.0.dev2 from 2021-01-08T09:51:58.524Z
906/2910 bhattlab/kraken2_classification: adding detected 'latest' among 1 records: kraken2_processing from 2021-04-15T23:16:38.645Z
907/2910 ast0815/highland2: adding detected 'latest' among 4 records: v2r59_prod7b from 2021-02-13T12:01:34.191Z
908/2910 hqhv/cuda_centos: adding detected 'latest' among 1 records: cuda_ubuntu from 2021-01-18T09:39:27.462Z
909/2910 HALFpipe/HALFpipe: adding detected 'latest' among 1 records: 1.0.0 from 2021-01-27T20:49:57.540Z
910/2910 fzimmermann89/Singularity: adding detected 'latest' among 2 records: ml from 2021-01-22T04:54:14.457Z
911/2910 ARPA-SIMC/nwprun: adding detected 'latest' among 1 records: nwprun from 2021-01-20T12:14:33.117Z
912/2910 haeriamin/singularity-ubuntu: adding detected 'latest' among 2 records: 1804gn from 2021-01-22T01:37:25.581Z
913/2910 guhur/singularity-collections: adding detected 'latest' among 1 records: snowflake from 2021-01-23T18:02:52.955Z
914/2910 aurelieGabriel/Imputation-nf: adding detected 'latest' among 1 records: v1.0 from 2021-01-25T07:50:39.697Z
915/2910 saviodot/singularity-r: adding detected 'latest' among 1 records: 4.0.2 from 2021-01-26T04:24:14.944Z
916/2910 jdmcdonagh/FEniCS-X: adding detected 'latest' among 2 records: openmpi2 from 2021-01-25T19:33:40.687Z
917/2910 gunesboun/singularity: adding detected 'latest' among 1 records: for_docker from 2021-01-25T21:05:59.632Z
918/2910 thomasp05/Adversarial_AI: adding detected 'latest' among 1 records: recipe from 2021-01-27T14:43:17.223Z
919/2910 skoyamamd/gtex_recipe: adding detected 'latest' among 2 records: v9 from 2021-02-13T14:12:49.001Z
920/2910 kiwiepic/fastqc: adding detected 'latest' among 1 records: 0.11.5 from 2021-02-01T10:02:48.800Z
921/2910 0luhancheng0/hpccm-containers: adding detected 'latest' among 7 records: nullarbor from 2021-04-18T06:45:02.559Z
922/2910 thomasp05/singularity_container: adding detected 'latest' among 1 records: recipe from 2021-02-01T15:17:48.591Z
923/2910 SergFern/Demultiplexing: adding detected 'latest' among 1 records: def from 2021-02-03T12:58:20.300Z
924/2910 shub-fuzz/aflpp: adding detected 'latest' among 1 records: 2004 from 2021-02-03T13:25:42.967Z
925/2910 kiwiepic/assembly-stats: adding detected 'latest' among 1 records: 17.02 from 2021-03-17T01:58:12.937Z
926/2910 jackjamend/CaptionContainer: adding detected 'latest' among 9 records: simple_torch-0.4 from 2021-03-25T18:41:02.721Z
927/2910 javaidm/layer_lab_chco: adding detected 'latest' among 1 records: def from 2021-02-23T21:30:56.954Z
928/2910 sschmeier/fishtank-gpu2: adding detected 'latest' among 1 records: 4.0.14 from 2021-02-23T07:06:52.287Z
929/2910 SofianeB/singularity-recipes: adding detected 'latest' among 1 records: ml from 2021-02-24T14:46:29.052Z
930/2910 baxpr/gf-edat: adding detected 'latest' among 2 records: v3.0.1 from 2021-03-18T15:20:51.069Z
931/2910 powellgenomicslab/SNP_genotype_contamination: adding detected 'latest' among 1 records: vices from 2021-03-08T06:08:29.339Z
932/2910 chaetognatha/singularity_library: adding detected 'latest' among 4 records: qc from 2021-03-15T11:29:41.703Z
933/2910 Bioape/Doktorand_test: adding detected 'latest' among 3 records: task1c from 2021-03-17T16:43:00.106Z
934/2910 togop/singularity_recipes: adding detected 'latest' among 1 records: scrnaseq from 2021-03-25T22:56:10.583Z
935/2910 SergFern/RNA_Seq_TCA: adding detected 'latest' among 1 records: def from 2021-03-15T14:22:20.171Z
936/2910 containrs/container: adding detected 'latest' among 1 records: antismash_standalone from 2021-04-12T11:51:22.531Z
937/2910 pmitev/UPPMAX-Singularity: adding detected 'latest' among 1 records: gapseq from 2021-03-17T09:49:52.092Z
938/2910 sskashaf/MAG_wf_containers_2021: adding detected 'latest' among 8 records: metagenome_preprocessing from 2021-04-17T02:51:52.172Z
939/2910 robomorelli/horovod_torch_nccl: adding detected 'latest' among 1 records: def from 2021-03-21T16:08:08.505Z
940/2910 dubelbog/ba_st_fairseq: adding detected 'latest' among 4 records: python_fairseq_container from 2021-03-24T22:42:03.168Z
941/2910 jmurga/bgd-pic: adding detected 'latest' among 2 records: breakseq from 2021-04-15T14:26:21.192Z
942/2910 reisportela/PythonCourse: adding detected 'latest' among 1 records: def from 2021-04-04T02:13:22.951Z
943/2910 kristinebilgrav/SVDB: adding detected 'latest' among 1 records: 2.4.0 from 2021-03-30T08:59:01.708Z
944/2910 KatSteinke/magician-singularity-containers: adding detected 'latest' among 3 records: cami_python2 from 2021-04-15T09:35:25.854Z
945/2910 sskashaf/SegreKong_containers: adding detected 'latest' among 1 records: eukcc from 2021-04-05T00:22:50.869Z
946/2910 kangzhiq/test_singularity: adding detected 'latest' among 1 records: lip2wav_tf2 from 2021-04-07T23:11:02.298Z
947/2910 nbarlowATI/shub-test: adding detected 'latest' among 2 records: basic from 2021-04-09T14:58:17.897Z
948/2910 radiantone/gsas2container: adding detected 'latest' among 1 records: gsas2 from 2021-04-17T01:37:04.886Z
949/2910 fenz-org/icc: adding detected 'latest' among 2 records: 2021.2-gcc-7.5 from 2021-04-12T20:02:15.683Z
950/2910 CATG-UMAG/bcell-lymphomas-mutational-signatures: adding detected 'latest' among 2 records: signature_analysis from 2021-04-15T02:56:55.556Z
951/2910 dongfang91/hpc-ml: adding detected 'latest' among 1 records: centos7-python3.7-transformers4.4.1 from 2021-04-16T02:01:51.873Z
952/2910 Romit-Maulik/singularity_recipes: adding detected 'latest' among 2 records: mpich33 from 2021-04-16T18:31:56.318Z
953/2910 KatSteinke/singularity-bbmap-metabat: adding detected 'latest' among 1 records: bbmap_from_metabat from 2021-04-16T11:51:16.935Z
954/2910 KatSteinke/singularity-camisim-standalone: adding detected 'latest' among 1 records: cami_python2 from 2021-04-16T11:50:17.376Z
955/2910 KatSteinke/singularity-drep-standalone: adding detected 'latest' among 1 records: drep from 2021-04-16T11:50:53.051Z

```
</details>

does it sound/look right @vsoch?